### PR TITLE
Modify base uri and add mechanism to do an Idempotent request

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For a full description of request and response payloads and properties, please s
 
 ### Send API
 
-* ```sendNotification(string $event, string $recipient, string $brand = NULL, array $profile = [], array $data = [], array $preferences = [], array $overrides = []): object``` [[?]](https://docs.courier.com/reference/send-api#sendmessage)
+* ```sendNotification(string $event, string $recipient, string $brand = NULL, array $profile = [], array $data = [], array $preferences = [], array $override = [], string $idempotency_key = NULL): object``` [[?]](https://docs.courier.com/reference/send-api#sendmessage)
 
 ### Messages API
 

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -16,4 +16,13 @@ class NotificationTest extends TestCase
         $this->assertEquals("/send", $response->path);
     }
 
+    public function test_send_idempotent_notification()
+    {
+        $response = $this->getCourierClient()->sendNotification("event", "recipient", NULL, [], [], [], [], "idempotent");
+
+        $this->assertEquals("POST", $response->method);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/send", $response->path);
+    }
+
 }


### PR DESCRIPTION
## Description of the change

> Support idempotency_key, change courier API base URI and modify `/send` API request param (overrides -> override)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> None

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
