### PR TITLE
Add array_filter to remove empty or null params in Send and Brands API

### DIFF
--- a/src/CourierClient.php
+++ b/src/CourierClient.php
@@ -222,7 +222,6 @@ final class CourierClient
      */
     public function sendNotification(string $event, string $recipient, string $brand = NULL, object $profile = NULL, object $data = NULL, object $preferences = NULL, object $override = NULL, string $idempotency_key = NULL): object
     {
-
         $params = array(
             'event' => $event,
             'recipient' => $recipient,
@@ -232,6 +231,8 @@ final class CourierClient
             'preferences' => $preferences,
             'override' => $override
         );
+        
+        $params = array_filter($params);
 
         return $this->doRequest(
             $idempotency_key ? $this->buildIdempotentRequest("post", "send", $params, $idempotency_key) 
@@ -267,6 +268,8 @@ final class CourierClient
             'data' => $data,
             'override' => $override
         );
+
+        $params = array_filter($params);
 
         return $this->doRequest(
             $idempotency_key ? $this->buildIdempotentRequest("post", "send/list", $params, $idempotency_key) 
@@ -525,6 +528,8 @@ final class CourierClient
             'snippets' => $snippets
         );
 
+        $params = array_filter($params);
+
         return $this->doRequest(
             $idempotency_key ? $this->buildIdempotentRequest("post", "brands", $params, $idempotency_key) 
             : $this->buildRequest("post", "brands", $params)
@@ -562,6 +567,8 @@ final class CourierClient
             'settings' => $settings,
             'snippets' => $snippets
         );
+
+        $params = array_filter($params);
 
         return $this->doRequest(
             $this->buildRequest("put", "brands/" . $brand_id, $params)


### PR DESCRIPTION
## Description of the change

> Removes params that are null objects or strings - applied to Send and Brands API

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> None

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
