### PR TITLE
[C-9648] adds support for accounts api

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ For a full description of request and response payloads and properties, please s
 - `getAuditEvent(string $audit_event_id): object` [(Get Audit Event)](https://www.courier.com/docs/reference/audit-events/by-id/)
 - `listAuditEvents(string $cursor = NULL): object` [(List Audit Events)](https://www.courier.com/docs/reference/audit-events/list/)
 
+### Accounts API
+
+- `getAccount(): object` [(Get Account)](https://www.courier.com/docs/reference/accounts/get-account/)
+- `listAccounts(string $cursor = NULL): object` [(List Accounts)](https://www.courier.com/docs/reference/accounts/get-accounts/)
+- `putAccount(string $account_id, string $name, string $timezone): object` [(Put Account)](https://www.courier.com/docs/reference/accounts/update/)
+- `deleteAccount(string $account_id): object` [(Delete Account)](https://www.courier.com/docs/reference/accounts/delete-account/)
+
 ## Errors
 
 All unsuccessful (non 2xx) responses will throw a `CourierRequestException`. The full response object is available via the `getResponse()` method.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For a full description of request and response payloads and properties, please s
 
 - `getAccount(): object` [(Get Account)](https://www.courier.com/docs/reference/accounts/get-account/)
 - `listAccounts(string $cursor = NULL): object` [(List Accounts)](https://www.courier.com/docs/reference/accounts/get-accounts/)
-- `putAccount(string $account_id, string $name, string $timezone): object` [(Put Account)](https://www.courier.com/docs/reference/accounts/update/)
+- `putAccount(string $account_id, object $account): object` [(Put Account)](https://www.courier.com/docs/reference/accounts/update/)
 - `deleteAccount(string $account_id): object` [(Delete Account)](https://www.courier.com/docs/reference/accounts/delete-account/)
 
 ## Errors

--- a/src/CourierClient.php
+++ b/src/CourierClient.php
@@ -12,7 +12,7 @@ final class CourierClient implements CourierClientInterface
     /**
      * @var string Library version, used for setting User-Agent
      */
-    private $version = '1.9.0';
+    private $version = '1.10.0';
 
     /**
      * Courier API base url.
@@ -1222,6 +1222,56 @@ final class CourierClient implements CourierClientInterface
 
         return $this->doRequest(
             $this->buildRequest("get", "audit-events?" . http_build_query($query_params, '', '&', PHP_QUERY_RFC3986))
+        );
+    }
+
+    /**
+     * Returns a list of Accounts in your workspace
+     * @param string|null $cursor
+     * @throws CourierRequestException
+     */
+    public function listAccounts(string $cursor = null): object
+    {
+        $query_params = array(
+            'cursor' => $cursor
+        );
+
+        return $this->doRequest(
+            $this->buildRequest("get", "accounts?" . http_build_query($query_params, '', '&', PHP_QUERY_RFC3986))
+        );
+    }
+
+    /**
+     * Returns a specific Account object
+     */
+    public function getAccount(string $account_id): object
+    {
+        return $this->doRequest(
+            $this->buildRequest("get", "accounts/" . $account_id)
+        );
+    }
+
+    /**
+     * Updates or creates an Account object
+     */
+    public function putAccount(string $account_id, object $account): object
+    {
+        $params = array(
+            'account' => $account
+        );
+
+        return $this->doRequest(
+            $this->buildRequest("put", "accounts/" . $account_id)
+        );
+    }
+
+    /**
+     * Deletes an Account object
+     */
+    public function deleteAccount(string $account_id): object
+    {
+        return $this->doRequest(
+            $this->buildRequest("delete", "accounts/" . $account_id)
         );
     }
 }

--- a/src/CourierClientInterface.php
+++ b/src/CourierClientInterface.php
@@ -64,4 +64,8 @@ interface CourierClientInterface
     public function getUserTokens(string $user_id): object;
     public function getAuditEvent(string $audit_event_id): object;
     public function listAuditEvents(string $cursor = null): object;
+    public function listAccounts(string $cursor = null): object;
+    public function getAccount(string $account_id): object;
+    public function putAccount(string $account_id, object $account): object;
+    public function deleteAccount(string $account_id): object;
 }

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -572,4 +572,37 @@ class NotificationTest extends TestCase
         $this->assertEquals("application/json", $response->content);
         $this->assertEquals("/audit-events", $response->path);
     }
+
+    public function test_list_accounts() {
+        $response = $this->getCourierClient()->listAccounts();
+
+        $this->assertEquals("GET", $response->method);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/accounts", $response->path);
+    }
+
+    public function test_get_account() {
+        $response = $this->getCourierClient()->getAccount("my-account");
+
+        $this->assertEquals("GET", $response->method);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/accounts/my-account", $response->path);
+    }
+
+    public function test_put_account() {
+        $account = (object) [];
+        $response = $this->getCourierClient()->putAccount("my-account", $account);
+
+        $this->assertEquals("PUT", $response->method);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/accounts/my-account", $response->path);
+    }
+
+    public function test_delete_account() {
+        $response = $this->getCourierClient()->deleteAccount("my-account");
+
+        $this->assertEquals("DELETE", $response->method);
+        $this->assertEquals("application/json", $response->content);
+        $this->assertEquals("/accounts/my-account", $response->path);
+    }
 }


### PR DESCRIPTION
## Description of the change

Adds support for [`/accounts` ](https://www.courier.com/docs/reference/accounts/intro/) API in PHP SDK

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

