### PR TITLE
docs: add AUTO-GENERATED-OVERVIEW markers for README sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
 # Courier PHP API library
 
 The Courier PHP library provides convenient access to the Courier REST API from any PHP 8.1.0+ application.
@@ -193,3 +194,4 @@ PHP 8.1.0 or higher.
 ## Contributing
 
 See [the contributing documentation](https://github.com/trycourier/courier-php/tree/main/CONTRIBUTING.md).
+<!-- AUTO-GENERATED-OVERVIEW:END -->


### PR DESCRIPTION
## Summary

- Adds `AUTO-GENERATED-OVERVIEW` markers around the existing README content
- These markers enable the [mintlify-docs sync workflow](https://github.com/trycourier/mintlify-docs/blob/main/.github/workflows/sync-readmes.yml) to automatically update the README overview section when documentation changes
- No content changes; just two HTML comment lines added