### PR TITLE
docs: sync README from mintlify-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then run `composer install`.
 ```php
 <?php
 
-use CourierClient;
+use Courier\Client;
 
 $client = new Client(apiKey: getenv('COURIER_API_KEY'));
 


### PR DESCRIPTION
## README Sync

Automated sync from [mintlify-docs](https://github.com/trycourier/mintlify-docs) export files.

### Synced files

- `README.md` (from `courier-php.md`)


### Timestamp

2026-02-20 18:36 UTC

---

*This PR was created automatically by the README sync workflow.*