### PR TITLE
fix(ci): drop Packagist secret requirement from release doctor

### DIFF
--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
+# Packagist publishing for trycourier/courier is handled by Packagist's GitHub
+# auto-update hook (webhook on new tags), NOT a CI push — so no PACKAGIST_USERNAME
+# / PACKAGIST_SAFE_KEY secrets are required (stainless.yml has php.publish.packagist:
+# false). This mirrors courier-node's token-less check (OIDC). Keep the errors array
+# so a future generated secret check slots back in cleanly.
 errors=()
-
-if [ -z "${PACKAGIST_USERNAME}" ]; then
-  errors+=("The PACKAGIST_USERNAME secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
-
-if [ -z "${PACKAGIST_SAFE_KEY}" ]; then
-  errors+=("The PACKAGIST_SAFE_KEY secret has not been set. Please set it in either this repository's secrets or your organization secrets")
-fi
 
 lenErrors=${#errors[@]}
 


### PR DESCRIPTION
## Problem
Every release PR shows a red **release doctor** check that fails in ~5s:
```
- The PACKAGIST_USERNAME secret has not been set...
- The PACKAGIST_SAFE_KEY secret has not been set...
```
But Packagist publishing for `trycourier/courier` is handled by **Packagist's GitHub auto-update hook** (webhook on new tags), not a CI push — so those secrets aren't needed. The package is current at **5.11.2**, matching the latest tag, i.e. publishing already works with **no token**.

## Root cause
`stainless.yml` already sets `php.publish.packagist: false` (2025-11-12), but this generated `bin/check-release-environment` was last synced **2025-10-07** — before that change — so it still demands the Packagist secrets. `courier-node`, which needs no publish secrets (OIDC), generates an **empty** check that always passes. php should look the same.

## Fix
Make `check-release-environment` token-less (empty `errors` array, always "ready"), matching courier-node. Publishing continues via the Packagist hook; this only removes the spurious red check.

## Note
This is a Stainless-generated file. It only regenerates on a settings-sync (last one was 2025-10-07), and when it does it should come out token-less anyway (given `packagist: false`), so this edit won't regress. The durable equivalent is a Stainless settings resync of this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)