### PR TITLE
chore(api): regenerate SDK

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
-configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0
+configured_endpoints: 150

--- a/src/Bulk/BulkAddUsersParams.php
+++ b/src/Bulk/BulkAddUsersParams.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Ingest user data into a Bulk Job.
+ *
+ * **Important**: For email-based bulk jobs, each user must include `profile.email`
+ * for provider routing to work correctly. The `to.email` field is not sufficient
+ * for email provider routing.
+ *
+ * @see Courier\Services\BulkService::addUsers()
+ *
+ * @phpstan-import-type InboundBulkMessageUserShape from \Courier\Bulk\InboundBulkMessageUser
+ *
+ * @phpstan-type BulkAddUsersParamsShape = array{
+ *   users: list<InboundBulkMessageUser|InboundBulkMessageUserShape>
+ * }
+ */
+final class BulkAddUsersParams implements BaseModel
+{
+    /** @use SdkModel<BulkAddUsersParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /** @var list<InboundBulkMessageUser> $users */
+    #[Required(list: InboundBulkMessageUser::class)]
+    public array $users;
+
+    /**
+     * `new BulkAddUsersParams()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * BulkAddUsersParams::with(users: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new BulkAddUsersParams)->withUsers(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<InboundBulkMessageUser|InboundBulkMessageUserShape> $users
+     */
+    public static function with(array $users): self
+    {
+        $self = new self;
+
+        $self['users'] = $users;
+
+        return $self;
+    }
+
+    /**
+     * @param list<InboundBulkMessageUser|InboundBulkMessageUserShape> $users
+     */
+    public function withUsers(array $users): self
+    {
+        $self = clone $this;
+        $self['users'] = $users;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkCreateJobParams.php
+++ b/src/Bulk/BulkCreateJobParams.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Creates a new bulk job for sending messages to multiple recipients.
+ *
+ * **Required**: `message.event` (event ID or notification ID)
+ *
+ * **Optional (V2 format)**: `message.template` (notification ID) or `message.content` (Elemental content)
+ * can be provided to override the notification associated with the event.
+ *
+ * @see Courier\Services\BulkService::createJob()
+ *
+ * @phpstan-import-type InboundBulkMessageShape from \Courier\Bulk\InboundBulkMessage
+ *
+ * @phpstan-type BulkCreateJobParamsShape = array{
+ *   message: InboundBulkMessage|InboundBulkMessageShape
+ * }
+ */
+final class BulkCreateJobParams implements BaseModel
+{
+    /** @use SdkModel<BulkCreateJobParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /**
+     * Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     */
+    #[Required]
+    public InboundBulkMessage $message;
+
+    /**
+     * `new BulkCreateJobParams()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * BulkCreateJobParams::with(message: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new BulkCreateJobParams)->withMessage(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $message
+     */
+    public static function with(InboundBulkMessage|array $message): self
+    {
+        $self = new self;
+
+        $self['message'] = $message;
+
+        return $self;
+    }
+
+    /**
+     * Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $message
+     */
+    public function withMessage(InboundBulkMessage|array $message): self
+    {
+        $self = clone $this;
+        $self['message'] = $message;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkGetJobResponse.php
+++ b/src/Bulk/BulkGetJobResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Bulk\BulkGetJobResponse\Job;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-import-type JobShape from \Courier\Bulk\BulkGetJobResponse\Job
+ *
+ * @phpstan-type BulkGetJobResponseShape = array{job: Job|JobShape}
+ */
+final class BulkGetJobResponse implements BaseModel
+{
+    /** @use SdkModel<BulkGetJobResponseShape> */
+    use SdkModel;
+
+    #[Required]
+    public Job $job;
+
+    /**
+     * `new BulkGetJobResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * BulkGetJobResponse::with(job: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new BulkGetJobResponse)->withJob(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param Job|JobShape $job
+     */
+    public static function with(Job|array $job): self
+    {
+        $self = new self;
+
+        $self['job'] = $job;
+
+        return $self;
+    }
+
+    /**
+     * @param Job|JobShape $job
+     */
+    public function withJob(Job|array $job): self
+    {
+        $self = clone $this;
+        $self['job'] = $job;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkGetJobResponse/Job.php
+++ b/src/Bulk/BulkGetJobResponse/Job.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk\BulkGetJobResponse;
+
+use Courier\Bulk\BulkGetJobResponse\Job\Status;
+use Courier\Bulk\InboundBulkMessage;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-import-type InboundBulkMessageShape from \Courier\Bulk\InboundBulkMessage
+ *
+ * @phpstan-type JobShape = array{
+ *   definition: InboundBulkMessage|InboundBulkMessageShape,
+ *   enqueued: int,
+ *   failures: int,
+ *   received: int,
+ *   status: Status|value-of<Status>,
+ * }
+ */
+final class Job implements BaseModel
+{
+    /** @use SdkModel<JobShape> */
+    use SdkModel;
+
+    /**
+     * Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     */
+    #[Required]
+    public InboundBulkMessage $definition;
+
+    #[Required]
+    public int $enqueued;
+
+    #[Required]
+    public int $failures;
+
+    #[Required]
+    public int $received;
+
+    /** @var value-of<Status> $status */
+    #[Required(enum: Status::class)]
+    public string $status;
+
+    /**
+     * `new Job()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * Job::with(
+     *   definition: ..., enqueued: ..., failures: ..., received: ..., status: ...
+     * )
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new Job)
+     *   ->withDefinition(...)
+     *   ->withEnqueued(...)
+     *   ->withFailures(...)
+     *   ->withReceived(...)
+     *   ->withStatus(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $definition
+     * @param Status|value-of<Status> $status
+     */
+    public static function with(
+        InboundBulkMessage|array $definition,
+        int $enqueued,
+        int $failures,
+        int $received,
+        Status|string $status,
+    ): self {
+        $self = new self;
+
+        $self['definition'] = $definition;
+        $self['enqueued'] = $enqueued;
+        $self['failures'] = $failures;
+        $self['received'] = $received;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $definition
+     */
+    public function withDefinition(InboundBulkMessage|array $definition): self
+    {
+        $self = clone $this;
+        $self['definition'] = $definition;
+
+        return $self;
+    }
+
+    public function withEnqueued(int $enqueued): self
+    {
+        $self = clone $this;
+        $self['enqueued'] = $enqueued;
+
+        return $self;
+    }
+
+    public function withFailures(int $failures): self
+    {
+        $self = clone $this;
+        $self['failures'] = $failures;
+
+        return $self;
+    }
+
+    public function withReceived(int $received): self
+    {
+        $self = clone $this;
+        $self['received'] = $received;
+
+        return $self;
+    }
+
+    /**
+     * @param Status|value-of<Status> $status
+     */
+    public function withStatus(Status|string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkGetJobResponse/Job/Status.php
+++ b/src/Bulk/BulkGetJobResponse/Job/Status.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk\BulkGetJobResponse\Job;
+
+enum Status: string
+{
+    case CREATED = 'CREATED';
+
+    case PROCESSING = 'PROCESSING';
+
+    case COMPLETED = 'COMPLETED';
+
+    case ERROR = 'ERROR';
+}

--- a/src/Bulk/BulkListUsersParams.php
+++ b/src/Bulk/BulkListUsersParams.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Get Bulk Job Users.
+ *
+ * @see Courier\Services\BulkService::listUsers()
+ *
+ * @phpstan-type BulkListUsersParamsShape = array{cursor?: string|null}
+ */
+final class BulkListUsersParams implements BaseModel
+{
+    /** @use SdkModel<BulkListUsersParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /**
+     * A unique identifier that allows for fetching the next set of users added to the bulk job.
+     */
+    #[Optional(nullable: true)]
+    public ?string $cursor;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(?string $cursor = null): self
+    {
+        $self = new self;
+
+        null !== $cursor && $self['cursor'] = $cursor;
+
+        return $self;
+    }
+
+    /**
+     * A unique identifier that allows for fetching the next set of users added to the bulk job.
+     */
+    public function withCursor(?string $cursor): self
+    {
+        $self = clone $this;
+        $self['cursor'] = $cursor;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkListUsersResponse.php
+++ b/src/Bulk/BulkListUsersResponse.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Bulk\BulkListUsersResponse\Item;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\Paging;
+
+/**
+ * @phpstan-import-type ItemShape from \Courier\Bulk\BulkListUsersResponse\Item
+ * @phpstan-import-type PagingShape from \Courier\Paging
+ *
+ * @phpstan-type BulkListUsersResponseShape = array{
+ *   items: list<Item|ItemShape>, paging: Paging|PagingShape
+ * }
+ */
+final class BulkListUsersResponse implements BaseModel
+{
+    /** @use SdkModel<BulkListUsersResponseShape> */
+    use SdkModel;
+
+    /** @var list<Item> $items */
+    #[Required(list: Item::class)]
+    public array $items;
+
+    #[Required]
+    public Paging $paging;
+
+    /**
+     * `new BulkListUsersResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * BulkListUsersResponse::with(items: ..., paging: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new BulkListUsersResponse)->withItems(...)->withPaging(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<Item|ItemShape> $items
+     * @param Paging|PagingShape $paging
+     */
+    public static function with(array $items, Paging|array $paging): self
+    {
+        $self = new self;
+
+        $self['items'] = $items;
+        $self['paging'] = $paging;
+
+        return $self;
+    }
+
+    /**
+     * @param list<Item|ItemShape> $items
+     */
+    public function withItems(array $items): self
+    {
+        $self = clone $this;
+        $self['items'] = $items;
+
+        return $self;
+    }
+
+    /**
+     * @param Paging|PagingShape $paging
+     */
+    public function withPaging(Paging|array $paging): self
+    {
+        $self = clone $this;
+        $self['paging'] = $paging;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkListUsersResponse/Item.php
+++ b/src/Bulk/BulkListUsersResponse/Item.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk\BulkListUsersResponse;
+
+use Courier\Bulk\BulkListUsersResponse\Item\Status;
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\RecipientPreferences;
+use Courier\UserRecipient;
+
+/**
+ * @phpstan-import-type RecipientPreferencesShape from \Courier\RecipientPreferences
+ * @phpstan-import-type UserRecipientShape from \Courier\UserRecipient
+ *
+ * @phpstan-type ItemShape = array{
+ *   data?: mixed,
+ *   preferences?: null|RecipientPreferences|RecipientPreferencesShape,
+ *   profile?: array<string,mixed>|null,
+ *   recipient?: string|null,
+ *   to?: null|UserRecipient|UserRecipientShape,
+ *   status: Status|value-of<Status>,
+ *   messageID?: string|null,
+ * }
+ */
+final class Item implements BaseModel
+{
+    /** @use SdkModel<ItemShape> */
+    use SdkModel;
+
+    /**
+     * User-specific data that will be merged with message.data.
+     */
+    #[Optional]
+    public mixed $data;
+
+    #[Optional]
+    public ?RecipientPreferences $preferences;
+
+    /**
+     * User profile information. For email-based bulk jobs, `profile.email` is required
+     * for provider routing to determine if the message can be delivered. The email
+     * address should be provided here rather than in `to.email`.
+     *
+     * @var array<string,mixed>|null $profile
+     */
+    #[Optional(map: 'mixed', nullable: true)]
+    public ?array $profile;
+
+    /**
+     * User ID (legacy field, use profile or to.user_id instead).
+     */
+    #[Optional(nullable: true)]
+    public ?string $recipient;
+
+    #[Optional]
+    public ?UserRecipient $to;
+
+    /** @var value-of<Status> $status */
+    #[Required(enum: Status::class)]
+    public string $status;
+
+    #[Optional('messageId', nullable: true)]
+    public ?string $messageID;
+
+    /**
+     * `new Item()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * Item::with(status: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new Item)->withStatus(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param Status|value-of<Status> $status
+     * @param RecipientPreferences|RecipientPreferencesShape|null $preferences
+     * @param array<string,mixed>|null $profile
+     * @param UserRecipient|UserRecipientShape|null $to
+     */
+    public static function with(
+        Status|string $status,
+        mixed $data = null,
+        RecipientPreferences|array|null $preferences = null,
+        ?array $profile = null,
+        ?string $recipient = null,
+        UserRecipient|array|null $to = null,
+        ?string $messageID = null,
+    ): self {
+        $self = new self;
+
+        $self['status'] = $status;
+
+        null !== $data && $self['data'] = $data;
+        null !== $preferences && $self['preferences'] = $preferences;
+        null !== $profile && $self['profile'] = $profile;
+        null !== $recipient && $self['recipient'] = $recipient;
+        null !== $to && $self['to'] = $to;
+        null !== $messageID && $self['messageID'] = $messageID;
+
+        return $self;
+    }
+
+    /**
+     * User-specific data that will be merged with message.data.
+     */
+    public function withData(mixed $data): self
+    {
+        $self = clone $this;
+        $self['data'] = $data;
+
+        return $self;
+    }
+
+    /**
+     * @param RecipientPreferences|RecipientPreferencesShape $preferences
+     */
+    public function withPreferences(
+        RecipientPreferences|array $preferences
+    ): self {
+        $self = clone $this;
+        $self['preferences'] = $preferences;
+
+        return $self;
+    }
+
+    /**
+     * User profile information. For email-based bulk jobs, `profile.email` is required
+     * for provider routing to determine if the message can be delivered. The email
+     * address should be provided here rather than in `to.email`.
+     *
+     * @param array<string,mixed>|null $profile
+     */
+    public function withProfile(?array $profile): self
+    {
+        $self = clone $this;
+        $self['profile'] = $profile;
+
+        return $self;
+    }
+
+    /**
+     * User ID (legacy field, use profile or to.user_id instead).
+     */
+    public function withRecipient(?string $recipient): self
+    {
+        $self = clone $this;
+        $self['recipient'] = $recipient;
+
+        return $self;
+    }
+
+    /**
+     * @param UserRecipient|UserRecipientShape $to
+     */
+    public function withTo(UserRecipient|array $to): self
+    {
+        $self = clone $this;
+        $self['to'] = $to;
+
+        return $self;
+    }
+
+    /**
+     * @param Status|value-of<Status> $status
+     */
+    public function withStatus(Status|string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    public function withMessageID(?string $messageID): self
+    {
+        $self = clone $this;
+        $self['messageID'] = $messageID;
+
+        return $self;
+    }
+}

--- a/src/Bulk/BulkListUsersResponse/Item/Status.php
+++ b/src/Bulk/BulkListUsersResponse/Item/Status.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk\BulkListUsersResponse\Item;
+
+enum Status: string
+{
+    case PENDING = 'PENDING';
+
+    case ENQUEUED = 'ENQUEUED';
+
+    case ERROR = 'ERROR';
+}

--- a/src/Bulk/BulkNewJobResponse.php
+++ b/src/Bulk/BulkNewJobResponse.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-type BulkNewJobResponseShape = array{jobID: string}
+ */
+final class BulkNewJobResponse implements BaseModel
+{
+    /** @use SdkModel<BulkNewJobResponseShape> */
+    use SdkModel;
+
+    #[Required('jobId')]
+    public string $jobID;
+
+    /**
+     * `new BulkNewJobResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * BulkNewJobResponse::with(jobID: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new BulkNewJobResponse)->withJobID(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(string $jobID): self
+    {
+        $self = new self;
+
+        $self['jobID'] = $jobID;
+
+        return $self;
+    }
+
+    public function withJobID(string $jobID): self
+    {
+        $self = clone $this;
+        $self['jobID'] = $jobID;
+
+        return $self;
+    }
+}

--- a/src/Bulk/InboundBulkMessage.php
+++ b/src/Bulk/InboundBulkMessage.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\Core\Conversion\MapOf;
+use Courier\ElementalContent;
+use Courier\ElementalContentSugar;
+
+/**
+ * Bulk message definition. Supports two formats:
+ * - V1 format: Requires `event` field (event ID or notification ID)
+ * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+ *
+ * @phpstan-import-type ContentVariants from \Courier\Bulk\InboundBulkMessage\Content
+ * @phpstan-import-type ContentShape from \Courier\Bulk\InboundBulkMessage\Content
+ *
+ * @phpstan-type InboundBulkMessageShape = array{
+ *   event: string,
+ *   brand?: string|null,
+ *   content?: ContentShape|null,
+ *   data?: array<string,mixed>|null,
+ *   locale?: array<string,array<string,mixed>>|null,
+ *   override?: array<string,mixed>|null,
+ *   template?: string|null,
+ * }
+ */
+final class InboundBulkMessage implements BaseModel
+{
+    /** @use SdkModel<InboundBulkMessageShape> */
+    use SdkModel;
+
+    /**
+     * Event ID or Notification ID (required). Can be either a
+     * Notification ID (e.g., "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a custom Event ID
+     * (e.g., "welcome-email") mapped to a notification.
+     */
+    #[Required]
+    public string $event;
+
+    #[Optional(nullable: true)]
+    public ?string $brand;
+
+    /**
+     * Elemental content (optional, for V2 format). When provided, this will be used
+     * instead of the notification associated with the `event` field.
+     *
+     * @var ContentVariants|null $content
+     */
+    #[Optional(nullable: true)]
+    public ElementalContentSugar|ElementalContent|null $content;
+
+    /** @var array<string,mixed>|null $data */
+    #[Optional(map: 'mixed', nullable: true)]
+    public ?array $data;
+
+    /** @var array<string,array<string,mixed>>|null $locale */
+    #[Optional(map: new MapOf('mixed'), nullable: true)]
+    public ?array $locale;
+
+    /** @var array<string,mixed>|null $override */
+    #[Optional(map: 'mixed', nullable: true)]
+    public ?array $override;
+
+    /**
+     * Notification ID or template ID (optional, for V2 format). When provided,
+     * this will be used instead of the notification associated with the `event` field.
+     */
+    #[Optional(nullable: true)]
+    public ?string $template;
+
+    /**
+     * `new InboundBulkMessage()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * InboundBulkMessage::with(event: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new InboundBulkMessage)->withEvent(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param ContentShape|null $content
+     * @param array<string,mixed>|null $data
+     * @param array<string,array<string,mixed>>|null $locale
+     * @param array<string,mixed>|null $override
+     */
+    public static function with(
+        string $event,
+        ?string $brand = null,
+        ElementalContentSugar|array|ElementalContent|null $content = null,
+        ?array $data = null,
+        ?array $locale = null,
+        ?array $override = null,
+        ?string $template = null,
+    ): self {
+        $self = new self;
+
+        $self['event'] = $event;
+
+        null !== $brand && $self['brand'] = $brand;
+        null !== $content && $self['content'] = $content;
+        null !== $data && $self['data'] = $data;
+        null !== $locale && $self['locale'] = $locale;
+        null !== $override && $self['override'] = $override;
+        null !== $template && $self['template'] = $template;
+
+        return $self;
+    }
+
+    /**
+     * Event ID or Notification ID (required). Can be either a
+     * Notification ID (e.g., "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a custom Event ID
+     * (e.g., "welcome-email") mapped to a notification.
+     */
+    public function withEvent(string $event): self
+    {
+        $self = clone $this;
+        $self['event'] = $event;
+
+        return $self;
+    }
+
+    public function withBrand(?string $brand): self
+    {
+        $self = clone $this;
+        $self['brand'] = $brand;
+
+        return $self;
+    }
+
+    /**
+     * Elemental content (optional, for V2 format). When provided, this will be used
+     * instead of the notification associated with the `event` field.
+     *
+     * @param ContentShape|null $content
+     */
+    public function withContent(
+        ElementalContentSugar|array|ElementalContent|null $content
+    ): self {
+        $self = clone $this;
+        $self['content'] = $content;
+
+        return $self;
+    }
+
+    /**
+     * @param array<string,mixed>|null $data
+     */
+    public function withData(?array $data): self
+    {
+        $self = clone $this;
+        $self['data'] = $data;
+
+        return $self;
+    }
+
+    /**
+     * @param array<string,array<string,mixed>>|null $locale
+     */
+    public function withLocale(?array $locale): self
+    {
+        $self = clone $this;
+        $self['locale'] = $locale;
+
+        return $self;
+    }
+
+    /**
+     * @param array<string,mixed>|null $override
+     */
+    public function withOverride(?array $override): self
+    {
+        $self = clone $this;
+        $self['override'] = $override;
+
+        return $self;
+    }
+
+    /**
+     * Notification ID or template ID (optional, for V2 format). When provided,
+     * this will be used instead of the notification associated with the `event` field.
+     */
+    public function withTemplate(?string $template): self
+    {
+        $self = clone $this;
+        $self['template'] = $template;
+
+        return $self;
+    }
+}

--- a/src/Bulk/InboundBulkMessage/Content.php
+++ b/src/Bulk/InboundBulkMessage/Content.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk\InboundBulkMessage;
+
+use Courier\Core\Concerns\SdkUnion;
+use Courier\Core\Conversion\Contracts\Converter;
+use Courier\Core\Conversion\Contracts\ConverterSource;
+use Courier\ElementalContent;
+use Courier\ElementalContentSugar;
+
+/**
+ * Elemental content (optional, for V2 format). When provided, this will be used
+ * instead of the notification associated with the `event` field.
+ *
+ * @phpstan-import-type ElementalContentSugarShape from \Courier\ElementalContentSugar
+ * @phpstan-import-type ElementalContentShape from \Courier\ElementalContent
+ *
+ * @phpstan-type ContentVariants = ElementalContentSugar|ElementalContent
+ * @phpstan-type ContentShape = ContentVariants|ElementalContentSugarShape|ElementalContentShape
+ */
+final class Content implements ConverterSource
+{
+    use SdkUnion;
+
+    /**
+     * @return list<string|Converter|ConverterSource>|array<string,string|Converter|ConverterSource>
+     */
+    public static function variants(): array
+    {
+        return [ElementalContentSugar::class, ElementalContent::class];
+    }
+}

--- a/src/Bulk/InboundBulkMessageUser.php
+++ b/src/Bulk/InboundBulkMessageUser.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Bulk;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\RecipientPreferences;
+use Courier\UserRecipient;
+
+/**
+ * @phpstan-import-type RecipientPreferencesShape from \Courier\RecipientPreferences
+ * @phpstan-import-type UserRecipientShape from \Courier\UserRecipient
+ *
+ * @phpstan-type InboundBulkMessageUserShape = array{
+ *   data?: mixed,
+ *   preferences?: null|RecipientPreferences|RecipientPreferencesShape,
+ *   profile?: array<string,mixed>|null,
+ *   recipient?: string|null,
+ *   to?: null|UserRecipient|UserRecipientShape,
+ * }
+ */
+final class InboundBulkMessageUser implements BaseModel
+{
+    /** @use SdkModel<InboundBulkMessageUserShape> */
+    use SdkModel;
+
+    /**
+     * User-specific data that will be merged with message.data.
+     */
+    #[Optional]
+    public mixed $data;
+
+    #[Optional(nullable: true)]
+    public ?RecipientPreferences $preferences;
+
+    /**
+     * User profile information. For email-based bulk jobs, `profile.email` is required
+     * for provider routing to determine if the message can be delivered. The email
+     * address should be provided here rather than in `to.email`.
+     *
+     * @var array<string,mixed>|null $profile
+     */
+    #[Optional(map: 'mixed', nullable: true)]
+    public ?array $profile;
+
+    /**
+     * User ID (legacy field, use profile or to.user_id instead).
+     */
+    #[Optional(nullable: true)]
+    public ?string $recipient;
+
+    /**
+     * Optional recipient information. Note: For email provider routing, use
+     * `profile.email` instead of `to.email`. The `to` field is primarily used
+     * for recipient identification and data merging.
+     */
+    #[Optional(nullable: true)]
+    public ?UserRecipient $to;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param RecipientPreferences|RecipientPreferencesShape|null $preferences
+     * @param array<string,mixed>|null $profile
+     * @param UserRecipient|UserRecipientShape|null $to
+     */
+    public static function with(
+        mixed $data = null,
+        RecipientPreferences|array|null $preferences = null,
+        ?array $profile = null,
+        ?string $recipient = null,
+        UserRecipient|array|null $to = null,
+    ): self {
+        $self = new self;
+
+        null !== $data && $self['data'] = $data;
+        null !== $preferences && $self['preferences'] = $preferences;
+        null !== $profile && $self['profile'] = $profile;
+        null !== $recipient && $self['recipient'] = $recipient;
+        null !== $to && $self['to'] = $to;
+
+        return $self;
+    }
+
+    /**
+     * User-specific data that will be merged with message.data.
+     */
+    public function withData(mixed $data): self
+    {
+        $self = clone $this;
+        $self['data'] = $data;
+
+        return $self;
+    }
+
+    /**
+     * @param RecipientPreferences|RecipientPreferencesShape|null $preferences
+     */
+    public function withPreferences(
+        RecipientPreferences|array|null $preferences
+    ): self {
+        $self = clone $this;
+        $self['preferences'] = $preferences;
+
+        return $self;
+    }
+
+    /**
+     * User profile information. For email-based bulk jobs, `profile.email` is required
+     * for provider routing to determine if the message can be delivered. The email
+     * address should be provided here rather than in `to.email`.
+     *
+     * @param array<string,mixed>|null $profile
+     */
+    public function withProfile(?array $profile): self
+    {
+        $self = clone $this;
+        $self['profile'] = $profile;
+
+        return $self;
+    }
+
+    /**
+     * User ID (legacy field, use profile or to.user_id instead).
+     */
+    public function withRecipient(?string $recipient): self
+    {
+        $self = clone $this;
+        $self['recipient'] = $recipient;
+
+        return $self;
+    }
+
+    /**
+     * Optional recipient information. Note: For email provider routing, use
+     * `profile.email` instead of `to.email`. The `to` field is primarily used
+     * for recipient identification and data merging.
+     *
+     * @param UserRecipient|UserRecipientShape|null $to
+     */
+    public function withTo(UserRecipient|array|null $to): self
+    {
+        $self = clone $this;
+        $self['to'] = $to;
+
+        return $self;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,6 +13,7 @@ use Courier\Services\AuthService;
 use Courier\Services\AutomationsService;
 use Courier\Services\BrandsService;
 use Courier\Services\BroadcastsService;
+use Courier\Services\BulkService;
 use Courier\Services\DigestsService;
 use Courier\Services\InboundService;
 use Courier\Services\JourneysService;
@@ -78,6 +79,11 @@ class Client extends BaseClient
      * @api
      */
     public BroadcastsService $broadcasts;
+
+    /**
+     * @api
+     */
+    public BulkService $bulk;
 
     /**
      * @api
@@ -177,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '5.4.2',
+            'X-Stainless-Package-Version' => '5.17.0',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),
@@ -208,6 +214,7 @@ class Client extends BaseClient
         $this->automations = new AutomationsService($this);
         $this->journeys = new JourneysService($this);
         $this->broadcasts = new BroadcastsService($this);
+        $this->bulk = new BulkService($this);
         $this->brands = new BrandsService($this);
         $this->digests = new DigestsService($this);
         $this->inbound = new InboundService($this);

--- a/src/Send/SendMessageParams.php
+++ b/src/Send/SendMessageParams.php
@@ -12,7 +12,7 @@ use Courier\Core\Contracts\BaseModel;
 use Courier\Send\SendMessageParams\Message;
 
 /**
- * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules.
+ * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules. Use the returned requestId to look up delivery status via the Messages API.
  *
  * @see Courier\Services\SendService::message()
  *

--- a/src/ServiceContracts/BulkContract.php
+++ b/src/ServiceContracts/BulkContract.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts;
+
+use Courier\Bulk\BulkGetJobResponse;
+use Courier\Bulk\BulkListUsersResponse;
+use Courier\Bulk\BulkNewJobResponse;
+use Courier\Bulk\InboundBulkMessage;
+use Courier\Bulk\InboundBulkMessageUser;
+use Courier\Core\Exceptions\APIException;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type InboundBulkMessageUserShape from \Courier\Bulk\InboundBulkMessageUser
+ * @phpstan-import-type InboundBulkMessageShape from \Courier\Bulk\InboundBulkMessage
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface BulkContract
+{
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param list<InboundBulkMessageUser|InboundBulkMessageUserShape> $users
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function addUsers(
+        string $jobID,
+        array $users,
+        RequestOptions|array|null $requestOptions = null,
+    ): mixed;
+
+    /**
+     * @api
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $message Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function createJob(
+        InboundBulkMessage|array $message,
+        RequestOptions|array|null $requestOptions = null,
+    ): BulkNewJobResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param string|null $cursor A unique identifier that allows for fetching the next set of users added to the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listUsers(
+        string $jobID,
+        ?string $cursor = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): BulkListUsersResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function retrieveJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BulkGetJobResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function runJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): mixed;
+}

--- a/src/ServiceContracts/BulkRawContract.php
+++ b/src/ServiceContracts/BulkRawContract.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts;
+
+use Courier\Bulk\BulkAddUsersParams;
+use Courier\Bulk\BulkCreateJobParams;
+use Courier\Bulk\BulkGetJobResponse;
+use Courier\Bulk\BulkListUsersParams;
+use Courier\Bulk\BulkListUsersResponse;
+use Courier\Bulk\BulkNewJobResponse;
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface BulkRawContract
+{
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param array<string,mixed>|BulkAddUsersParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<mixed>
+     *
+     * @throws APIException
+     */
+    public function addUsers(
+        string $jobID,
+        array|BulkAddUsersParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param array<string,mixed>|BulkCreateJobParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkNewJobResponse>
+     *
+     * @throws APIException
+     */
+    public function createJob(
+        array|BulkCreateJobParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param array<string,mixed>|BulkListUsersParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkListUsersResponse>
+     *
+     * @throws APIException
+     */
+    public function listUsers(
+        string $jobID,
+        array|BulkListUsersParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkGetJobResponse>
+     *
+     * @throws APIException
+     */
+    public function retrieveJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<mixed>
+     *
+     * @throws APIException
+     */
+    public function runJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+}

--- a/src/Services/BulkRawService.php
+++ b/src/Services/BulkRawService.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services;
+
+use Courier\Bulk\BulkAddUsersParams;
+use Courier\Bulk\BulkCreateJobParams;
+use Courier\Bulk\BulkGetJobResponse;
+use Courier\Bulk\BulkListUsersParams;
+use Courier\Bulk\BulkListUsersResponse;
+use Courier\Bulk\BulkNewJobResponse;
+use Courier\Bulk\InboundBulkMessage;
+use Courier\Bulk\InboundBulkMessageUser;
+use Courier\Client;
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\BulkRawContract;
+
+/**
+ * @phpstan-import-type InboundBulkMessageUserShape from \Courier\Bulk\InboundBulkMessageUser
+ * @phpstan-import-type InboundBulkMessageShape from \Courier\Bulk\InboundBulkMessage
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class BulkRawService implements BulkRawContract
+{
+    // @phpstan-ignore-next-line
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client) {}
+
+    /**
+     * @api
+     *
+     * Ingest user data into a Bulk Job.
+     *
+     * **Important**: For email-based bulk jobs, each user must include `profile.email`
+     * for provider routing to work correctly. The `to.email` field is not sufficient
+     * for email provider routing.
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param array{
+     *   users: list<InboundBulkMessageUser|InboundBulkMessageUserShape>
+     * }|BulkAddUsersParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<mixed>
+     *
+     * @throws APIException
+     */
+    public function addUsers(
+        string $jobID,
+        array|BulkAddUsersParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = BulkAddUsersParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'post',
+            path: ['bulk/%1$s', $jobID],
+            body: (object) $parsed,
+            options: $options,
+            convert: null,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * Creates a new bulk job for sending messages to multiple recipients.
+     *
+     * **Required**: `message.event` (event ID or notification ID)
+     *
+     * **Optional (V2 format)**: `message.template` (notification ID) or `message.content` (Elemental content)
+     * can be provided to override the notification associated with the event.
+     *
+     * @param array{
+     *   message: InboundBulkMessage|InboundBulkMessageShape
+     * }|BulkCreateJobParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkNewJobResponse>
+     *
+     * @throws APIException
+     */
+    public function createJob(
+        array|BulkCreateJobParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = BulkCreateJobParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'post',
+            path: 'bulk',
+            body: (object) $parsed,
+            options: $options,
+            convert: BulkNewJobResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * Get Bulk Job Users
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param array{cursor?: string|null}|BulkListUsersParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkListUsersResponse>
+     *
+     * @throws APIException
+     */
+    public function listUsers(
+        string $jobID,
+        array|BulkListUsersParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = BulkListUsersParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['bulk/%1$s/users', $jobID],
+            query: $parsed,
+            options: $options,
+            convert: BulkListUsersResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * Get a bulk job
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<BulkGetJobResponse>
+     *
+     * @throws APIException
+     */
+    public function retrieveJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse {
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['bulk/%1$s', $jobID],
+            options: $requestOptions,
+            convert: BulkGetJobResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * Run a bulk job
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<mixed>
+     *
+     * @throws APIException
+     */
+    public function runJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse {
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'post',
+            path: ['bulk/%1$s/run', $jobID],
+            options: $requestOptions,
+            convert: null,
+        );
+    }
+}

--- a/src/Services/BulkService.php
+++ b/src/Services/BulkService.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services;
+
+use Courier\Bulk\BulkGetJobResponse;
+use Courier\Bulk\BulkListUsersResponse;
+use Courier\Bulk\BulkNewJobResponse;
+use Courier\Bulk\InboundBulkMessage;
+use Courier\Bulk\InboundBulkMessageUser;
+use Courier\Client;
+use Courier\Core\Exceptions\APIException;
+use Courier\Core\Util;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\BulkContract;
+
+/**
+ * @phpstan-import-type InboundBulkMessageUserShape from \Courier\Bulk\InboundBulkMessageUser
+ * @phpstan-import-type InboundBulkMessageShape from \Courier\Bulk\InboundBulkMessage
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class BulkService implements BulkContract
+{
+    /**
+     * @api
+     */
+    public BulkRawService $raw;
+
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client)
+    {
+        $this->raw = new BulkRawService($client);
+    }
+
+    /**
+     * @api
+     *
+     * Ingest user data into a Bulk Job.
+     *
+     * **Important**: For email-based bulk jobs, each user must include `profile.email`
+     * for provider routing to work correctly. The `to.email` field is not sufficient
+     * for email provider routing.
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param list<InboundBulkMessageUser|InboundBulkMessageUserShape> $users
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function addUsers(
+        string $jobID,
+        array $users,
+        RequestOptions|array|null $requestOptions = null,
+    ): mixed {
+        $params = Util::removeNulls(['users' => $users]);
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->addUsers($jobID, params: $params, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * Creates a new bulk job for sending messages to multiple recipients.
+     *
+     * **Required**: `message.event` (event ID or notification ID)
+     *
+     * **Optional (V2 format)**: `message.template` (notification ID) or `message.content` (Elemental content)
+     * can be provided to override the notification associated with the event.
+     *
+     * @param InboundBulkMessage|InboundBulkMessageShape $message Bulk message definition. Supports two formats:
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental content) in addition to `event`
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function createJob(
+        InboundBulkMessage|array $message,
+        RequestOptions|array|null $requestOptions = null,
+    ): BulkNewJobResponse {
+        $params = Util::removeNulls(['message' => $message]);
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->createJob(params: $params, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * Get Bulk Job Users
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param string|null $cursor A unique identifier that allows for fetching the next set of users added to the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listUsers(
+        string $jobID,
+        ?string $cursor = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): BulkListUsersResponse {
+        $params = Util::removeNulls(['cursor' => $cursor]);
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->listUsers($jobID, params: $params, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * Get a bulk job
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function retrieveJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): BulkGetJobResponse {
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->retrieveJob($jobID, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * Run a bulk job
+     *
+     * @param string $jobID A unique identifier representing the bulk job
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function runJob(
+        string $jobID,
+        RequestOptions|array|null $requestOptions = null
+    ): mixed {
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->runJob($jobID, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+}

--- a/src/Services/SendRawService.php
+++ b/src/Services/SendRawService.php
@@ -31,7 +31,7 @@ final class SendRawService implements SendRawContract
     /**
      * @api
      *
-     * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules.
+     * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules. Use the returned requestId to look up delivery status via the Messages API.
      *
      * @param array{
      *   message: Message|MessageShape,

--- a/src/Services/SendService.php
+++ b/src/Services/SendService.php
@@ -36,7 +36,7 @@ final class SendService implements SendContract
     /**
      * @api
      *
-     * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules.
+     * Sends a message to one or more recipients and returns a requestId. Courier routes it to email, SMS, push, chat, or in-app based on your rules. Use the returned requestId to look up delivery status via the Messages API.
      *
      * @param Message|MessageShape $message Body param: The message property has the following primary top-level properties. They define the destination and content of the message.
      * @param string $idempotencyKey Header param: A unique key that makes this request idempotent. If Courier receives another request with the same `Idempotency-Key`, it returns the stored response from the first request without performing the operation again (including the original status code and any error). Use it to safely retry `POST` requests after network failures without risking duplicate sends. The key is scoped to this endpoint.

--- a/tests/Services/BulkTest.php
+++ b/tests/Services/BulkTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Services;
+
+use Courier\Bulk\BulkGetJobResponse;
+use Courier\Bulk\BulkListUsersResponse;
+use Courier\Bulk\BulkNewJobResponse;
+use Courier\ChannelClassification;
+use Courier\Client;
+use Courier\Core\Util;
+use Courier\PreferenceStatus;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\UnsupportedMockTests;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class BulkTest extends TestCase
+{
+    protected Client $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $testUrl = Util::getenv('TEST_API_BASE_URL') ?: 'http://127.0.0.1:4010';
+        $client = new Client(apiKey: 'My API Key', baseUrl: $testUrl);
+
+        $this->client = $client;
+    }
+
+    #[Test]
+    public function testAddUsers(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->addUsers('job_id', users: [[]]);
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function testAddUsersWithOptionalParams(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->addUsers(
+            'job_id',
+            users: [
+                [
+                    'data' => (object) [],
+                    'preferences' => [
+                        'categories' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                        'notifications' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                    ],
+                    'profile' => ['foo' => 'bar'],
+                    'recipient' => 'recipient',
+                    'to' => [
+                        'accountID' => 'account_id',
+                        'context' => ['tenantID' => 'tenant_id'],
+                        'data' => ['foo' => 'bar'],
+                        'email' => 'email',
+                        'listID' => 'list_id',
+                        'locale' => 'locale',
+                        'phoneNumber' => 'phone_number',
+                        'preferences' => [
+                            'notifications' => [
+                                'foo' => [
+                                    'status' => PreferenceStatus::OPTED_IN,
+                                    'channelPreferences' => [
+                                        ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                    ],
+                                    'rules' => [['until' => 'until', 'start' => 'start']],
+                                    'source' => 'subscription',
+                                ],
+                            ],
+                            'categories' => [
+                                'foo' => [
+                                    'status' => PreferenceStatus::OPTED_IN,
+                                    'channelPreferences' => [
+                                        ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                    ],
+                                    'rules' => [['until' => 'until', 'start' => 'start']],
+                                    'source' => 'subscription',
+                                ],
+                            ],
+                            'templateID' => 'templateId',
+                        ],
+                        'tenantID' => 'tenant_id',
+                        'userID' => 'user_id',
+                    ],
+                ],
+            ],
+        );
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function testCreateJob(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->createJob(message: ['event' => 'event']);
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(BulkNewJobResponse::class, $result);
+    }
+
+    #[Test]
+    public function testCreateJobWithOptionalParams(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->createJob(
+            message: [
+                'event' => 'event',
+                'brand' => 'brand',
+                'content' => ['body' => 'body', 'title' => 'title'],
+                'data' => ['foo' => 'bar'],
+                'locale' => ['foo' => ['foo' => 'bar']],
+                'override' => ['foo' => 'bar'],
+                'template' => 'template',
+            ],
+        );
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(BulkNewJobResponse::class, $result);
+    }
+
+    #[Test]
+    public function testListUsers(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->listUsers('job_id');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(BulkListUsersResponse::class, $result);
+    }
+
+    #[Test]
+    public function testRetrieveJob(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->retrieveJob('job_id');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(BulkGetJobResponse::class, $result);
+    }
+
+    #[Test]
+    public function testRunJob(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->bulk->runJob('job_id');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

23 files changed, 1990 insertions(+), 8 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                     |   5 +-
 src/Bulk/BulkAddUsersParams.php                |  82 ++++++++++++++++++
 src/Bulk/BulkCreateJobParams.php               |  91 ++++++++++++++++++++
 src/Bulk/BulkGetJobResponse.php                |  70 +++++++++++++++
 src/Bulk/BulkGetJobResponse/Job.php            | 151 ++++++++++++++++++++++++++++++++
 src/Bulk/BulkGetJobResponse/Job/Status.php     |  16 ++++
 src/Bulk/BulkListUsersParams.php               |  60 +++++++++++++
 src/Bulk/BulkListUsersResponse.php             |  91 ++++++++++++++++++++
 src/Bulk/BulkListUsersResponse/Item.php        | 199 ++++++++++++++++++++++++++++++++++++++++++
 src/Bulk/BulkListUsersResponse/Item/Status.php |  14 +++
 src/Bulk/BulkNewJobResponse.php                |  62 ++++++++++++++
 src/Bulk/InboundBulkMessage.php                | 209 +++++++++++++++++++++++++++++++++++++++++++++
 src/Bulk/InboundBulkMessage/Content.php        |  34 ++++++++
 src/Bulk/InboundBulkMessageUser.php            | 158 ++++++++++++++++++++++++++++++++++
 src/Client.php                                 |   9 +-
 src/Send/SendMessageParams.php                 |   2 +-
 src/ServiceContracts/BulkContract.php          |  92 ++++++++++++++++++++
 src/ServiceContracts/BulkRawContract.php       | 100 ++++++++++++++++++++++
 src/Services/BulkRawService.php                | 193 +++++++++++++++++++++++++++++++++++++++++
 src/Services/BulkService.php                   | 158 ++++++++++++++++++++++++++++++++++
 src/Services/SendRawService.php                |   2 +-
 src/Services/SendService.php                   |   2 +-
 tests/Services/BulkTest.php                    | 198 ++++++++++++++++++++++++++++++++++++++++++
 23 files changed, 1990 insertions(+), 8 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
