### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/tests/Services/Automations/InvokeTest.php
+++ b/tests/Services/Automations/InvokeTest.php
@@ -91,7 +91,7 @@ final class InvokeTest extends TestCase
 
         $result = $this->client->automations->invoke->invokeByTemplate(
             'templateId',
-            recipient: 'recipient'
+            recipient: 'user_abc'
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -107,10 +107,10 @@ final class InvokeTest extends TestCase
 
         $result = $this->client->automations->invoke->invokeByTemplate(
             'templateId',
-            recipient: 'recipient',
+            recipient: 'user_abc',
             brand: 'brand',
-            data: ['foo' => 'bar'],
-            profile: ['foo' => 'bar'],
+            data: ['orderId' => 'bar'],
+            profile: ['email' => 'bar'],
             template: 'template',
             idempotencyKey: 'order-ORD-456-user-123',
             xIdempotencyExpiration: '1785312000',

--- a/tests/Services/BrandsTest.php
+++ b/tests/Services/BrandsTest.php
@@ -124,7 +124,7 @@ final class BrandsTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->brands->update('brand_id', name: 'name');
+        $result = $this->client->brands->update('brand_id', name: 'My Brand');
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertInstanceOf(Brand::class, $result);
@@ -139,9 +139,9 @@ final class BrandsTest extends TestCase
 
         $result = $this->client->brands->update(
             'brand_id',
-            name: 'name',
+            name: 'My Brand',
             settings: [
-                'colors' => ['primary' => 'primary', 'secondary' => 'secondary'],
+                'colors' => ['primary' => '#9D3789', 'secondary' => '#FFFFFF'],
                 'email' => [
                     'footer' => ['content' => 'content', 'inheritDefault' => true],
                     'head' => ['inheritDefault' => true, 'content' => 'content'],

--- a/tests/Services/BulkTest.php
+++ b/tests/Services/BulkTest.php
@@ -56,7 +56,7 @@ final class BulkTest extends TestCase
             'job_id',
             users: [
                 [
-                    'data' => (object) [],
+                    'data' => ['name' => 'Jane'],
                     'preferences' => [
                         'categories' => [
                             'foo' => [
@@ -77,8 +77,8 @@ final class BulkTest extends TestCase
                             ],
                         ],
                     ],
-                    'profile' => ['foo' => 'bar'],
-                    'recipient' => 'recipient',
+                    'profile' => ['email' => 'bar'],
+                    'recipient' => 'user_abc',
                     'to' => [
                         'accountID' => 'account_id',
                         'context' => ['tenantID' => 'tenant_id'],
@@ -128,7 +128,9 @@ final class BulkTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->bulk->createJob(message: ['event' => 'event']);
+        $result = $this->client->bulk->createJob(
+            message: ['event' => 'welcome-series']
+        );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertInstanceOf(BulkNewJobResponse::class, $result);
@@ -143,10 +145,10 @@ final class BulkTest extends TestCase
 
         $result = $this->client->bulk->createJob(
             message: [
-                'event' => 'event',
-                'brand' => 'brand',
+                'event' => 'welcome-series',
+                'brand' => 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
                 'content' => ['body' => 'body', 'title' => 'title'],
-                'data' => ['foo' => 'bar'],
+                'data' => ['campaign' => 'bar'],
                 'locale' => ['foo' => ['foo' => 'bar']],
                 'override' => ['foo' => 'bar'],
                 'template' => 'template',

--- a/tests/Services/Lists/SubscriptionsTest.php
+++ b/tests/Services/Lists/SubscriptionsTest.php
@@ -52,7 +52,9 @@ final class SubscriptionsTest extends TestCase
 
         $result = $this->client->lists->subscriptions->add(
             'list_id',
-            recipients: [['recipientID' => 'recipientId']]
+            recipients: [
+                ['recipientID' => 'user_abc'], ['recipientID' => 'user_def'],
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -70,7 +72,30 @@ final class SubscriptionsTest extends TestCase
             'list_id',
             recipients: [
                 [
-                    'recipientID' => 'recipientId',
+                    'recipientID' => 'user_abc',
+                    'preferences' => [
+                        'categories' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                        'notifications' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'recipientID' => 'user_def',
                     'preferences' => [
                         'categories' => [
                             'foo' => [
@@ -110,7 +135,9 @@ final class SubscriptionsTest extends TestCase
 
         $result = $this->client->lists->subscriptions->subscribe(
             'list_id',
-            recipients: [['recipientID' => 'recipientId']]
+            recipients: [
+                ['recipientID' => 'user_abc'], ['recipientID' => 'user_def'],
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -128,7 +155,30 @@ final class SubscriptionsTest extends TestCase
             'list_id',
             recipients: [
                 [
-                    'recipientID' => 'recipientId',
+                    'recipientID' => 'user_abc',
+                    'preferences' => [
+                        'categories' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                        'notifications' => [
+                            'foo' => [
+                                'status' => PreferenceStatus::OPTED_IN,
+                                'channelPreferences' => [
+                                    ['channel' => ChannelClassification::DIRECT_MESSAGE],
+                                ],
+                                'rules' => [['until' => 'until', 'start' => 'start']],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'recipientID' => 'user_def',
                     'preferences' => [
                         'categories' => [
                             'foo' => [
@@ -194,7 +244,7 @@ final class SubscriptionsTest extends TestCase
                     ],
                 ],
                 'notifications' => [
-                    'foo' => [
+                    'nt_01kx4h2jdafq8bk9aftxak4b40' => [
                         'status' => PreferenceStatus::OPTED_IN,
                         'channelPreferences' => [
                             ['channel' => ChannelClassification::DIRECT_MESSAGE],

--- a/tests/Services/ListsTest.php
+++ b/tests/Services/ListsTest.php
@@ -51,7 +51,7 @@ final class ListsTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->lists->update('list_id', name: 'name');
+        $result = $this->client->lists->update('list_id', name: 'Product Updates');
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertNull($result);
@@ -66,7 +66,7 @@ final class ListsTest extends TestCase
 
         $result = $this->client->lists->update(
             'list_id',
-            name: 'name',
+            name: 'Product Updates',
             preferences: [
                 'categories' => [
                     'foo' => [

--- a/tests/Services/Notifications/ChecksTest.php
+++ b/tests/Services/Notifications/ChecksTest.php
@@ -39,7 +39,7 @@ final class ChecksTest extends TestCase
         $result = $this->client->notifications->checks->update(
             'submissionId',
             id: 'id',
-            checks: [['id' => 'id', 'status' => 'RESOLVED', 'type' => 'custom']],
+            checks: [['id' => 'abc-123', 'status' => 'RESOLVED', 'type' => 'custom']],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -56,7 +56,7 @@ final class ChecksTest extends TestCase
         $result = $this->client->notifications->checks->update(
             'submissionId',
             id: 'id',
-            checks: [['id' => 'id', 'status' => 'RESOLVED', 'type' => 'custom']],
+            checks: [['id' => 'abc-123', 'status' => 'RESOLVED', 'type' => 'custom']],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType

--- a/tests/Services/Profiles/ListsTest.php
+++ b/tests/Services/Profiles/ListsTest.php
@@ -67,7 +67,7 @@ final class ListsTest extends TestCase
 
         $result = $this->client->profiles->lists->subscribe(
             'user_id',
-            lists: [['listID' => 'listId']]
+            lists: [['listID' => 'example.list.id']]
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -85,7 +85,7 @@ final class ListsTest extends TestCase
             'user_id',
             lists: [
                 [
-                    'listID' => 'listId',
+                    'listID' => 'example.list.id',
                     'preferences' => [
                         'categories' => [
                             'foo' => [

--- a/tests/Services/ProfilesTest.php
+++ b/tests/Services/ProfilesTest.php
@@ -39,7 +39,7 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->create(
             'user_id',
-            profile: ['foo' => 'bar']
+            profile: ['email' => 'bar', 'phone_number' => 'bar']
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -55,7 +55,7 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->create(
             'user_id',
-            profile: ['foo' => 'bar'],
+            profile: ['email' => 'bar', 'phone_number' => 'bar'],
             idempotencyKey: 'order-ORD-456-user-123',
             xIdempotencyExpiration: '1785312000',
         );
@@ -86,7 +86,9 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->update(
             'user_id',
-            patch: [['op' => 'op', 'path' => 'path', 'value' => 'value']]
+            patch: [
+                ['op' => 'replace', 'path' => '/email', 'value' => 'jdoe@example.com'],
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -102,7 +104,9 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->update(
             'user_id',
-            patch: [['op' => 'op', 'path' => 'path', 'value' => 'value']]
+            patch: [
+                ['op' => 'replace', 'path' => '/email', 'value' => 'jdoe@example.com'],
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -131,7 +135,7 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->replace(
             'user_id',
-            profile: ['foo' => 'bar']
+            profile: ['email' => 'bar', 'phone_number' => 'bar', 'locale' => 'bar'],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -147,7 +151,7 @@ final class ProfilesTest extends TestCase
 
         $result = $this->client->profiles->replace(
             'user_id',
-            profile: ['foo' => 'bar']
+            profile: ['email' => 'bar', 'phone_number' => 'bar', 'locale' => 'bar'],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType

--- a/tests/Services/ProvidersTest.php
+++ b/tests/Services/ProvidersTest.php
@@ -36,7 +36,7 @@ final class ProvidersTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->providers->create(provider: 'provider');
+        $result = $this->client->providers->create(provider: 'sendgrid');
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertInstanceOf(Provider::class, $result);
@@ -50,10 +50,10 @@ final class ProvidersTest extends TestCase
         }
 
         $result = $this->client->providers->create(
-            provider: 'provider',
+            provider: 'sendgrid',
             alias: 'alias',
-            settings: ['foo' => 'bar'],
-            title: 'title',
+            settings: ['api_key' => 'bar'],
+            title: 'Production SendGrid',
             idempotencyKey: 'order-ORD-456-user-123',
             xIdempotencyExpiration: '1785312000',
         );
@@ -82,7 +82,7 @@ final class ProvidersTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->providers->update('id', provider: 'provider');
+        $result = $this->client->providers->update('id', provider: 'sendgrid');
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertInstanceOf(Provider::class, $result);
@@ -97,10 +97,10 @@ final class ProvidersTest extends TestCase
 
         $result = $this->client->providers->update(
             'id',
-            provider: 'provider',
+            provider: 'sendgrid',
             alias: 'alias',
-            settings: ['foo' => 'bar'],
-            title: 'title',
+            settings: ['api_key' => 'bar'],
+            title: 'Production SendGrid',
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType

--- a/tests/Services/Tenants/TemplatesTest.php
+++ b/tests/Services/Tenants/TemplatesTest.php
@@ -134,7 +134,7 @@ final class TemplatesTest extends TestCase
         $result = $this->client->tenants->templates->publish(
             'template_id',
             tenantID: 'tenant_id',
-            version: 'version'
+            version: 'latest'
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -151,7 +151,7 @@ final class TemplatesTest extends TestCase
         $result = $this->client->tenants->templates->replace(
             'template_id',
             tenantID: 'tenant_id',
-            template: ['content' => ['elements' => [[]], 'version' => 'version']],
+            template: ['content' => ['elements' => [[]], 'version' => '2022-01-01']],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -179,7 +179,7 @@ final class TemplatesTest extends TestCase
                             'type' => 'text',
                         ],
                     ],
-                    'version' => 'version',
+                    'version' => '2022-01-01',
                 ],
                 'channels' => [
                     'foo' => [
@@ -216,7 +216,7 @@ final class TemplatesTest extends TestCase
                         'timeouts' => 0,
                     ],
                 ],
-                'routing' => ['channels' => ['string'], 'method' => 'all'],
+                'routing' => ['channels' => ['email'], 'method' => 'single'],
             ],
             published: true,
         );

--- a/tests/Services/TenantsTest.php
+++ b/tests/Services/TenantsTest.php
@@ -51,7 +51,7 @@ final class TenantsTest extends TestCase
             $this->markTestSkipped('Mock server tests are disabled');
         }
 
-        $result = $this->client->tenants->update('tenant_id', name: 'name');
+        $result = $this->client->tenants->update('tenant_id', name: 'Acme Corp');
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertInstanceOf(Tenant::class, $result);
@@ -66,8 +66,8 @@ final class TenantsTest extends TestCase
 
         $result = $this->client->tenants->update(
             'tenant_id',
-            name: 'name',
-            brandID: 'brand_id',
+            name: 'Acme Corp',
+            brandID: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
             defaultPreferences: [
                 'items' => [
                     [
@@ -79,7 +79,7 @@ final class TenantsTest extends TestCase
                 ],
             ],
             parentTenantID: 'parent_tenant_id',
-            properties: ['foo' => 'bar'],
+            properties: ['plan' => 'bar'],
             userProfile: ['foo' => 'bar'],
         );
 

--- a/tests/Services/TranslationsTest.php
+++ b/tests/Services/TranslationsTest.php
@@ -63,7 +63,7 @@ final class TranslationsTest extends TestCase
         $result = $this->client->translations->update(
             'locale',
             domain: 'domain',
-            body: 'body'
+            body: "msgid \"Hello\"\nmsgstr \"Hola\""
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -80,7 +80,7 @@ final class TranslationsTest extends TestCase
         $result = $this->client->translations->update(
             'locale',
             domain: 'domain',
-            body: 'body'
+            body: "msgid \"Hello\"\nmsgstr \"Hola\""
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType

--- a/tests/Services/Users/TenantsTest.php
+++ b/tests/Services/Users/TenantsTest.php
@@ -50,7 +50,7 @@ final class TenantsTest extends TestCase
 
         $result = $this->client->users->tenants->addMultiple(
             'user_id',
-            tenants: [['tenantID' => 'tenant_id']]
+            tenants: [['tenantID' => 'tenant_abc'], ['tenantID' => 'tenant_def']],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -68,7 +68,13 @@ final class TenantsTest extends TestCase
             'user_id',
             tenants: [
                 [
-                    'tenantID' => 'tenant_id',
+                    'tenantID' => 'tenant_abc',
+                    'profile' => ['foo' => 'bar'],
+                    'type' => 'user',
+                    'userID' => 'user_id',
+                ],
+                [
+                    'tenantID' => 'tenant_def',
                     'profile' => ['foo' => 'bar'],
                     'type' => 'user',
                     'userID' => 'user_id',
@@ -106,7 +112,7 @@ final class TenantsTest extends TestCase
         $result = $this->client->users->tenants->addSingle(
             'tenant_id',
             userID: 'user_id',
-            profile: ['foo' => 'bar']
+            profile: ['role' => 'bar']
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType

--- a/tests/Services/Users/TokensTest.php
+++ b/tests/Services/Users/TokensTest.php
@@ -71,7 +71,7 @@ final class TokensTest extends TestCase
         $result = $this->client->users->tokens->update(
             'token',
             userID: 'user_id',
-            patch: [['op' => 'op', 'path' => 'path']]
+            patch: [['op' => 'replace', 'path' => '/expiry_date']],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -88,7 +88,13 @@ final class TokensTest extends TestCase
         $result = $this->client->users->tokens->update(
             'token',
             userID: 'user_id',
-            patch: [['op' => 'op', 'path' => 'path', 'value' => 'value']],
+            patch: [
+                [
+                    'op' => 'replace',
+                    'path' => '/expiry_date',
+                    'value' => '2024-12-31T00:00:00.000Z',
+                ],
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -177,7 +183,7 @@ final class TokensTest extends TestCase
             providerKey: 'firebase-fcm',
             device: [
                 'adID' => 'ad_id',
-                'appID' => 'app_id',
+                'appID' => 'com.example.app',
                 'deviceID' => 'device_id',
                 'manufacturer' => 'manufacturer',
                 'model' => 'model',

--- a/tests/Services/WorkspacePreferences/TopicsTest.php
+++ b/tests/Services/WorkspacePreferences/TopicsTest.php
@@ -173,8 +173,8 @@ final class TopicsTest extends TestCase
         $result = $this->client->workspacePreferences->topics->replace(
             'topic_id',
             sectionID: 'section_id',
-            defaultStatus: 'OPTED_OUT',
-            name: 'name',
+            defaultStatus: 'OPTED_IN',
+            name: 'Product Updates',
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -194,12 +194,14 @@ final class TopicsTest extends TestCase
         $result = $this->client->workspacePreferences->topics->replace(
             'topic_id',
             sectionID: 'section_id',
-            defaultStatus: 'OPTED_OUT',
-            name: 'name',
-            allowedPreferences: ['snooze'],
+            defaultStatus: 'OPTED_IN',
+            name: 'Product Updates',
+            allowedPreferences: ['channel_preferences'],
             description: 'description',
             includeUnsubscribeHeader: true,
-            routingOptions: [ChannelClassification::DIRECT_MESSAGE],
+            routingOptions: [
+                ChannelClassification::EMAIL, ChannelClassification::INBOX,
+            ],
             topicData: ['foo' => 'bar'],
         );
 

--- a/tests/Services/WorkspacePreferencesTest.php
+++ b/tests/Services/WorkspacePreferencesTest.php
@@ -127,7 +127,7 @@ final class WorkspacePreferencesTest extends TestCase
 
         $result = $this->client->workspacePreferences->replace(
             'section_id',
-            name: 'name'
+            name: 'Account Notifications'
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
@@ -143,10 +143,12 @@ final class WorkspacePreferencesTest extends TestCase
 
         $result = $this->client->workspacePreferences->replace(
             'section_id',
-            name: 'name',
+            name: 'Account Notifications',
             description: 'description',
             hasCustomRouting: true,
-            routingOptions: [ChannelClassification::DIRECT_MESSAGE],
+            routingOptions: [
+                ChannelClassification::EMAIL, ChannelClassification::PUSH,
+            ],
         );
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

16 files changed, 136 insertions(+), 64 deletions(-)

<details><summary>Files</summary>

```
 tests/Services/Automations/InvokeTest.php          |  8 +++---
 tests/Services/BrandsTest.php                      |  6 ++---
 tests/Services/BulkTest.php                        | 16 ++++++-----
 tests/Services/Lists/SubscriptionsTest.php         | 60 ++++++++++++++++++++++++++++++++++++++----
 tests/Services/ListsTest.php                       |  4 +--
 tests/Services/Notifications/ChecksTest.php        |  4 +--
 tests/Services/Profiles/ListsTest.php              |  4 +--
 tests/Services/ProfilesTest.php                    | 16 ++++++-----
 tests/Services/ProvidersTest.php                   | 16 +++++------
 tests/Services/Tenants/TemplatesTest.php           |  8 +++---
 tests/Services/TenantsTest.php                     |  8 +++---
 tests/Services/TranslationsTest.php                |  4 +--
 tests/Services/Users/TenantsTest.php               | 12 ++++++---
 tests/Services/Users/TokensTest.php                | 12 ++++++---
 tests/Services/WorkspacePreferences/TopicsTest.php | 14 +++++-----
 tests/Services/WorkspacePreferencesTest.php        |  8 +++---
 16 files changed, 136 insertions(+), 64 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
