### PR TITLE
docs(api): describe every broadcast id path parameter

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '5.17.0',
+            'X-Stainless-Package-Version' => '5.17.1',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/ServiceContracts/BroadcastsContract.php
+++ b/src/ServiceContracts/BroadcastsContract.php
@@ -39,6 +39,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to retrieve, identified by the `id` returned when it was created
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -51,6 +52,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to rename
      * @param string $name new human-readable name
      * @param RequestOpts|null $requestOptions
      *
@@ -80,6 +82,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to archive
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -92,6 +95,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to cancel
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -104,6 +108,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID The broadcast to copy. The duplicate is created as a new draft and this broadcast is left unchanged.
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -116,6 +121,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast whose content you want to replace
      * @param Content|ContentShape $content Elemental content payload. The server defaults `version` when omitted.
      * @param NotificationTemplateState|value-of<NotificationTemplateState> $state Template state. Defaults to `DRAFT`.
      * @param RequestOpts|null $requestOptions
@@ -132,6 +138,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast whose content you want to read
      * @param string $version Accepts `draft`, `published`, or a version string (e.g. `v001`). Defaults to `draft`.
      * @param RequestOpts|null $requestOptions
      *
@@ -146,6 +153,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to schedule
      * @param string $recipientID ID of the target list or audience
      * @param RecipientType|value-of<RecipientType> $recipientType whether the broadcast targets a list or an audience
      * @param string $scheduledTo Wall-clock timestamp of the future send, no timezone offset (e.g. "2026-07-21T20:00:00"). The zone is given by `timezone`.
@@ -166,6 +174,7 @@ interface BroadcastsContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to send
      * @param string $recipientID ID of the target list or audience
      * @param \Courier\Broadcasts\BroadcastSendParams\RecipientType|value-of<\Courier\Broadcasts\BroadcastSendParams\RecipientType> $recipientType whether the broadcast targets a list or an audience
      * @param RequestOpts|null $requestOptions

--- a/src/ServiceContracts/BroadcastsRawContract.php
+++ b/src/ServiceContracts/BroadcastsRawContract.php
@@ -42,6 +42,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to retrieve, identified by the `id` returned when it was created
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -56,6 +57,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to rename
      * @param array<string,mixed>|BroadcastUpdateParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -87,6 +89,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to archive
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -101,6 +104,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to cancel
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -115,6 +119,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID The broadcast to copy. The duplicate is created as a new draft and this broadcast is left unchanged.
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -129,6 +134,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast whose content you want to replace
      * @param array<string,mixed>|BroadcastPutContentParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -145,6 +151,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast whose content you want to read
      * @param array<string,mixed>|BroadcastRetrieveContentParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -161,6 +168,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to schedule
      * @param array<string,mixed>|BroadcastScheduleParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -177,6 +185,7 @@ interface BroadcastsRawContract
     /**
      * @api
      *
+     * @param string $broadcastID the broadcast to send
      * @param array<string,mixed>|BroadcastSendParams $params
      * @param RequestOpts|null $requestOptions
      *

--- a/src/Services/BroadcastsRawService.php
+++ b/src/Services/BroadcastsRawService.php
@@ -77,6 +77,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Retrieve a broadcast by ID. Archived broadcasts return 404.
      *
+     * @param string $broadcastID the broadcast to retrieve, identified by the `id` returned when it was created
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -101,6 +102,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Update a broadcast's name. Content is edited via the broadcast's notification template, not this endpoint.
      *
+     * @param string $broadcastID the broadcast to rename
      * @param array{name: string}|BroadcastUpdateParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -164,6 +166,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Archive a broadcast. This is a soft delete — the archived broadcast is returned and no longer appears in list results.
      *
+     * @param string $broadcastID the broadcast to archive
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -188,6 +191,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Cancel a broadcast's pending schedule, returning it to the draft state. Only valid for a scheduled broadcast.
      *
+     * @param string $broadcastID the broadcast to cancel
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -212,6 +216,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Duplicate a broadcast (and its template) into a new draft named "{source name} (copy)".
      *
+     * @param string $broadcastID The broadcast to copy. The duplicate is created as a new draft and this broadcast is left unchanged.
      * @param RequestOpts|null $requestOptions
      *
      * @return BaseResponse<Broadcast>
@@ -236,6 +241,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Author the broadcast's content by replacing the draft elemental content of its private notification template. The draft is published automatically when the broadcast is sent or scheduled.
      *
+     * @param string $broadcastID the broadcast whose content you want to replace
      * @param array{
      *   content: Content|ContentShape,
      *   state?: NotificationTemplateState|value-of<NotificationTemplateState>,
@@ -271,6 +277,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Retrieve the broadcast's content — the elemental content of its private notification template. Defaults to the working draft, since broadcast content is authored as a draft until the broadcast is sent.
      *
+     * @param string $broadcastID the broadcast whose content you want to read
      * @param array{version?: string}|BroadcastRetrieveContentParams $params
      * @param RequestOpts|null $requestOptions
      *
@@ -303,6 +310,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Schedule a broadcast for a future send to a list or audience. Publishes the broadcast template first. Not allowed once the broadcast is sending or sent. For an immediate send use POST /broadcasts/{broadcastId}/send.
      *
+     * @param string $broadcastID the broadcast to schedule
      * @param array{
      *   recipientID: string,
      *   recipientType: RecipientType|value-of<RecipientType>,
@@ -340,6 +348,7 @@ final class BroadcastsRawService implements BroadcastsRawContract
      *
      * Send a broadcast immediately to a list or audience. Publishes the broadcast template first. Not allowed once the broadcast is sending or sent.
      *
+     * @param string $broadcastID the broadcast to send
      * @param array{
      *   recipientID: string,
      *   recipientType: BroadcastSendParams\RecipientType|value-of<BroadcastSendParams\RecipientType>,

--- a/src/Services/BroadcastsService.php
+++ b/src/Services/BroadcastsService.php
@@ -68,6 +68,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Retrieve a broadcast by ID. Archived broadcasts return 404.
      *
+     * @param string $broadcastID the broadcast to retrieve, identified by the `id` returned when it was created
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -87,6 +88,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Update a broadcast's name. Content is edited via the broadcast's notification template, not this endpoint.
      *
+     * @param string $broadcastID the broadcast to rename
      * @param string $name new human-readable name
      * @param RequestOpts|null $requestOptions
      *
@@ -134,6 +136,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Archive a broadcast. This is a soft delete — the archived broadcast is returned and no longer appears in list results.
      *
+     * @param string $broadcastID the broadcast to archive
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -153,6 +156,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Cancel a broadcast's pending schedule, returning it to the draft state. Only valid for a scheduled broadcast.
      *
+     * @param string $broadcastID the broadcast to cancel
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -172,6 +176,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Duplicate a broadcast (and its template) into a new draft named "{source name} (copy)".
      *
+     * @param string $broadcastID The broadcast to copy. The duplicate is created as a new draft and this broadcast is left unchanged.
      * @param RequestOpts|null $requestOptions
      *
      * @throws APIException
@@ -191,6 +196,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Author the broadcast's content by replacing the draft elemental content of its private notification template. The draft is published automatically when the broadcast is sent or scheduled.
      *
+     * @param string $broadcastID the broadcast whose content you want to replace
      * @param Content|ContentShape $content Elemental content payload. The server defaults `version` when omitted.
      * @param NotificationTemplateState|value-of<NotificationTemplateState> $state Template state. Defaults to `DRAFT`.
      * @param RequestOpts|null $requestOptions
@@ -216,6 +222,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Retrieve the broadcast's content — the elemental content of its private notification template. Defaults to the working draft, since broadcast content is authored as a draft until the broadcast is sent.
      *
+     * @param string $broadcastID the broadcast whose content you want to read
      * @param string $version Accepts `draft`, `published`, or a version string (e.g. `v001`). Defaults to `draft`.
      * @param RequestOpts|null $requestOptions
      *
@@ -239,6 +246,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Schedule a broadcast for a future send to a list or audience. Publishes the broadcast template first. Not allowed once the broadcast is sending or sent. For an immediate send use POST /broadcasts/{broadcastId}/send.
      *
+     * @param string $broadcastID the broadcast to schedule
      * @param string $recipientID ID of the target list or audience
      * @param RecipientType|value-of<RecipientType> $recipientType whether the broadcast targets a list or an audience
      * @param string $scheduledTo Wall-clock timestamp of the future send, no timezone offset (e.g. "2026-07-21T20:00:00"). The zone is given by `timezone`.
@@ -275,6 +283,7 @@ final class BroadcastsService implements BroadcastsContract
      *
      * Send a broadcast immediately to a list or audience. Publishes the broadcast template first. Not allowed once the broadcast is sending or sent.
      *
+     * @param string $broadcastID the broadcast to send
      * @param string $recipientID ID of the target list or audience
      * @param \Courier\Broadcasts\BroadcastSendParams\RecipientType|value-of<\Courier\Broadcasts\BroadcastSendParams\RecipientType> $recipientType whether the broadcast targets a list or an audience
      * @param RequestOpts|null $requestOptions


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

5 files changed, 37 insertions(+), 1 deletion(-)

<details><summary>Files</summary>

```
 src/Client.php                                 | 2 +-
 src/ServiceContracts/BroadcastsContract.php    | 9 +++++++++
 src/ServiceContracts/BroadcastsRawContract.php | 9 +++++++++
 src/Services/BroadcastsRawService.php          | 9 +++++++++
 src/Services/BroadcastsService.php             | 9 +++++++++
 5 files changed, 37 insertions(+), 1 deletion(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
