### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/src/Bulk/BulkListUsersParams.php
+++ b/src/Bulk/BulkListUsersParams.php
@@ -10,7 +10,7 @@ use Courier\Core\Concerns\SdkParams;
 use Courier\Core\Contracts\BaseModel;
 
 /**
- * Get Bulk Job Users.
+ * Returns the users ingested into a bulk job with paging, each carrying the status Courier recorded for it and the id of the message it produced.
  *
  * @see Courier\Services\BulkService::listUsers()
  *

--- a/src/Services/BulkRawService.php
+++ b/src/Services/BulkRawService.php
@@ -111,7 +111,7 @@ final class BulkRawService implements BulkRawContract
     /**
      * @api
      *
-     * Get Bulk Job Users
+     * Returns the users ingested into a bulk job with paging, each carrying the status Courier recorded for it and the id of the message it produced.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param array{cursor?: string|null}|BulkListUsersParams $params
@@ -144,7 +144,7 @@ final class BulkRawService implements BulkRawContract
     /**
      * @api
      *
-     * Get a bulk job
+     * Returns a bulk job's message definition, its status — CREATED, PROCESSING, COMPLETED, or ERROR — and running counts of users received, messages enqueued, and failures. Poll it to follow a job through to completion.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param RequestOpts|null $requestOptions
@@ -169,7 +169,7 @@ final class BulkRawService implements BulkRawContract
     /**
      * @api
      *
-     * Run a bulk job
+     * Starts processing a bulk job, sending to every user ingested into it. Returns 204 immediately; the job runs asynchronously, so poll the job to watch its status and counts.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param RequestOpts|null $requestOptions

--- a/src/Services/BulkService.php
+++ b/src/Services/BulkService.php
@@ -95,7 +95,7 @@ final class BulkService implements BulkContract
     /**
      * @api
      *
-     * Get Bulk Job Users
+     * Returns the users ingested into a bulk job with paging, each carrying the status Courier recorded for it and the id of the message it produced.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param string|null $cursor A unique identifier that allows for fetching the next set of users added to the bulk job
@@ -119,7 +119,7 @@ final class BulkService implements BulkContract
     /**
      * @api
      *
-     * Get a bulk job
+     * Returns a bulk job's message definition, its status — CREATED, PROCESSING, COMPLETED, or ERROR — and running counts of users received, messages enqueued, and failures. Poll it to follow a job through to completion.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param RequestOpts|null $requestOptions
@@ -139,7 +139,7 @@ final class BulkService implements BulkContract
     /**
      * @api
      *
-     * Run a bulk job
+     * Starts processing a bulk job, sending to every user ingested into it. Returns 204 immediately; the job runs asynchronously, so poll the job to watch its status and counts.
      *
      * @param string $jobID A unique identifier representing the bulk job
      * @param RequestOpts|null $requestOptions


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 7 insertions(+), 7 deletions(-)

<details><summary>Files</summary>

```
 src/Bulk/BulkListUsersParams.php | 2 +-
 src/Services/BulkRawService.php  | 6 +++---
 src/Services/BulkService.php     | 6 +++---
 3 files changed, 7 insertions(+), 7 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
