### PR TITLE
feat(api)!: match the spec to the backend — apn/expo token types and the phantom notifications.duplicate

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 150
+configured_endpoints: 149

--- a/src/Apn.php
+++ b/src/Apn.php
@@ -9,15 +9,15 @@ use Courier\Core\Conversion\Contracts\Converter;
 use Courier\Core\Conversion\Contracts\ConverterSource;
 
 /**
- * Expo push tokens. Supply either a single `token` or a `tokens` value.
+ * Apple Push Notification device tokens. Supply either a single `token` or a `tokens` value. A bare string is rejected by the provider — the token must be wrapped in this object.
  *
  * @phpstan-import-type TokenShape from \Courier\Token
  * @phpstan-import-type MultipleTokensShape from \Courier\MultipleTokens
  *
- * @phpstan-type ExpoVariants = Token|MultipleTokens
- * @phpstan-type ExpoShape = ExpoVariants|TokenShape|MultipleTokensShape
+ * @phpstan-type ApnVariants = Token|MultipleTokens
+ * @phpstan-type ApnShape = ApnVariants|TokenShape|MultipleTokensShape
  */
-final class Expo implements ConverterSource
+final class Apn implements ConverterSource
 {
     use SdkUnion;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '5.17.2',
+            'X-Stainless-Package-Version' => '6.0.0',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/MultipleTokens.php
+++ b/src/MultipleTokens.php
@@ -7,20 +7,26 @@ namespace Courier;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
+use Courier\MultipleTokens\Tokens;
 
 /**
- * @phpstan-import-type TokenShape from \Courier\Token
+ * @phpstan-import-type TokensVariants from \Courier\MultipleTokens\Tokens
+ * @phpstan-import-type TokensShape from \Courier\MultipleTokens\Tokens
  *
- * @phpstan-type MultipleTokensShape = array{tokens: list<Token|TokenShape>}
+ * @phpstan-type MultipleTokensShape = array{tokens: TokensShape}
  */
 final class MultipleTokens implements BaseModel
 {
     /** @use SdkModel<MultipleTokensShape> */
     use SdkModel;
 
-    /** @var list<Token> $tokens */
-    #[Required(list: Token::class)]
-    public array $tokens;
+    /**
+     * One device token, or an array of them. The values are the token strings themselves — not objects.
+     *
+     * @var TokensVariants $tokens
+     */
+    #[Required(union: Tokens::class)]
+    public string|array $tokens;
 
     /**
      * `new MultipleTokens()` is missing required properties by the API.
@@ -46,9 +52,9 @@ final class MultipleTokens implements BaseModel
      *
      * You must use named parameters to construct any parameters with a default value.
      *
-     * @param list<Token|TokenShape> $tokens
+     * @param TokensShape $tokens
      */
-    public static function with(array $tokens): self
+    public static function with(string|array $tokens): self
     {
         $self = new self;
 
@@ -58,9 +64,11 @@ final class MultipleTokens implements BaseModel
     }
 
     /**
-     * @param list<Token|TokenShape> $tokens
+     * One device token, or an array of them. The values are the token strings themselves — not objects.
+     *
+     * @param TokensShape $tokens
      */
-    public function withTokens(array $tokens): self
+    public function withTokens(string|array $tokens): self
     {
         $self = clone $this;
         $self['tokens'] = $tokens;

--- a/src/MultipleTokens/Tokens.php
+++ b/src/MultipleTokens/Tokens.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\MultipleTokens;
+
+use Courier\Core\Concerns\SdkUnion;
+use Courier\Core\Conversion\Contracts\Converter;
+use Courier\Core\Conversion\Contracts\ConverterSource;
+use Courier\Core\Conversion\ListOf;
+
+/**
+ * One device token, or an array of them. The values are the token strings themselves — not objects.
+ *
+ * @phpstan-type TokensVariants = string|list<string>
+ * @phpstan-type TokensShape = TokensVariants
+ */
+final class Tokens implements ConverterSource
+{
+    use SdkUnion;
+
+    /**
+     * @return list<string|Converter|ConverterSource>|array<string,string|Converter|ConverterSource>
+     */
+    public static function variants(): array
+    {
+        return ['string', new ListOf('string')];
+    }
+}

--- a/src/ServiceContracts/NotificationsContract.php
+++ b/src/ServiceContracts/NotificationsContract.php
@@ -94,19 +94,6 @@ interface NotificationsContract
      * @api
      *
      * @param string $id template ID (nt_ prefix)
-     * @param RequestOpts|null $requestOptions
-     *
-     * @throws APIException
-     */
-    public function duplicate(
-        string $id,
-        RequestOptions|array|null $requestOptions = null
-    ): NotificationTemplateResponse;
-
-    /**
-     * @api
-     *
-     * @param string $id template ID (nt_ prefix)
      * @param string $cursor Opaque pagination cursor from a previous response. Omit for the first page.
      * @param int $limit Maximum number of versions to return per page. Default 10, max 10.
      * @param RequestOpts|null $requestOptions

--- a/src/ServiceContracts/NotificationsRawContract.php
+++ b/src/ServiceContracts/NotificationsRawContract.php
@@ -95,21 +95,6 @@ interface NotificationsRawContract
      * @api
      *
      * @param string $id template ID (nt_ prefix)
-     * @param RequestOpts|null $requestOptions
-     *
-     * @return BaseResponse<NotificationTemplateResponse>
-     *
-     * @throws APIException
-     */
-    public function duplicate(
-        string $id,
-        RequestOptions|array|null $requestOptions = null
-    ): BaseResponse;
-
-    /**
-     * @api
-     *
-     * @param string $id template ID (nt_ prefix)
      * @param array<string,mixed>|NotificationListVersionsParams $params
      * @param RequestOpts|null $requestOptions
      *

--- a/src/Services/NotificationsRawService.php
+++ b/src/Services/NotificationsRawService.php
@@ -190,31 +190,6 @@ final class NotificationsRawService implements NotificationsRawContract
     /**
      * @api
      *
-     * Copies a notification template within the same workspace and environment, appending " COPY" to the title. The copy is standalone and independently editable.
-     *
-     * @param string $id template ID (nt_ prefix)
-     * @param RequestOpts|null $requestOptions
-     *
-     * @return BaseResponse<NotificationTemplateResponse>
-     *
-     * @throws APIException
-     */
-    public function duplicate(
-        string $id,
-        RequestOptions|array|null $requestOptions = null
-    ): BaseResponse {
-        // @phpstan-ignore-next-line return.type
-        return $this->client->request(
-            method: 'post',
-            path: ['notifications/%1$s/duplicate', $id],
-            options: $requestOptions,
-            convert: NotificationTemplateResponse::class,
-        );
-    }
-
-    /**
-     * @api
-     *
      * Returns a notification template's published versions, most recent first, for comparison or rollback. Paged.
      *
      * @param string $id template ID (nt_ prefix)

--- a/src/Services/NotificationsService.php
+++ b/src/Services/NotificationsService.php
@@ -161,26 +161,6 @@ final class NotificationsService implements NotificationsContract
     /**
      * @api
      *
-     * Copies a notification template within the same workspace and environment, appending " COPY" to the title. The copy is standalone and independently editable.
-     *
-     * @param string $id template ID (nt_ prefix)
-     * @param RequestOpts|null $requestOptions
-     *
-     * @throws APIException
-     */
-    public function duplicate(
-        string $id,
-        RequestOptions|array|null $requestOptions = null
-    ): NotificationTemplateResponse {
-        // @phpstan-ignore-next-line argument.type
-        $response = $this->raw->duplicate($id, requestOptions: $requestOptions);
-
-        return $response->parse();
-    }
-
-    /**
-     * @api
-     *
      * Returns a notification template's published versions, most recent first, for comparison or rollback. Paged.
      *
      * @param string $id template ID (nt_ prefix)

--- a/src/UserProfile.php
+++ b/src/UserProfile.php
@@ -10,6 +10,7 @@ use Courier\Core\Contracts\BaseModel;
 use Courier\UserProfile\Address;
 
 /**
+ * @phpstan-import-type ApnVariants from \Courier\Apn
  * @phpstan-import-type DiscordVariants from \Courier\Discord
  * @phpstan-import-type ExpoVariants from \Courier\Expo
  * @phpstan-import-type UserProfileFirebaseTokenVariants from \Courier\UserProfileFirebaseToken
@@ -17,6 +18,7 @@ use Courier\UserProfile\Address;
  * @phpstan-import-type SlackVariants from \Courier\Slack
  * @phpstan-import-type AddressShape from \Courier\UserProfile\Address
  * @phpstan-import-type AirshipProfileShape from \Courier\AirshipProfile
+ * @phpstan-import-type ApnShape from \Courier\Apn
  * @phpstan-import-type AwsSnsShape from \Courier\AwsSns
  * @phpstan-import-type DiscordShape from \Courier\Discord
  * @phpstan-import-type ExpoShape from \Courier\Expo
@@ -28,7 +30,7 @@ use Courier\UserProfile\Address;
  * @phpstan-type UserProfileShape = array{
  *   address?: null|Address|AddressShape,
  *   airship?: null|AirshipProfile|AirshipProfileShape,
- *   apn?: string|null,
+ *   apn?: ApnShape|null,
  *   awsSns?: null|AwsSns|AwsSnsShape,
  *   birthdate?: string|null,
  *   custom?: array<string,mixed>|null,
@@ -70,8 +72,13 @@ final class UserProfile implements BaseModel
     #[Optional(nullable: true)]
     public ?AirshipProfile $airship;
 
+    /**
+     * Apple Push Notification device tokens. Supply either a single `token` or a `tokens` value. A bare string is rejected by the provider — the token must be wrapped in this object.
+     *
+     * @var ApnVariants|null $apn
+     */
     #[Optional(nullable: true)]
-    public ?string $apn;
+    public Token|MultipleTokens|null $apn;
 
     /**
      * Routes a push notification through the AWS SNS provider. The target ARN must be nested under `aws_sns` — a top-level `target_arn` on the profile is ignored by the provider.
@@ -100,7 +107,11 @@ final class UserProfile implements BaseModel
     #[Optional('email_verified', nullable: true)]
     public ?bool $emailVerified;
 
-    /** @var ExpoVariants|null $expo */
+    /**
+     * Expo push tokens. Supply either a single `token` or a `tokens` value.
+     *
+     * @var ExpoVariants|null $expo
+     */
     #[Optional(nullable: true)]
     public Token|MultipleTokens|null $expo;
 
@@ -182,6 +193,7 @@ final class UserProfile implements BaseModel
      *
      * @param Address|AddressShape|null $address
      * @param AirshipProfile|AirshipProfileShape|null $airship
+     * @param ApnShape|null $apn
      * @param AwsSns|AwsSnsShape|null $awsSns
      * @param array<string,mixed>|null $custom
      * @param DiscordShape|null $discord
@@ -194,7 +206,7 @@ final class UserProfile implements BaseModel
     public static function with(
         Address|array|null $address = null,
         AirshipProfile|array|null $airship = null,
-        ?string $apn = null,
+        Token|array|MultipleTokens|null $apn = null,
         AwsSns|array|null $awsSns = null,
         ?string $birthdate = null,
         ?array $custom = null,
@@ -283,7 +295,12 @@ final class UserProfile implements BaseModel
         return $self;
     }
 
-    public function withApn(?string $apn): self
+    /**
+     * Apple Push Notification device tokens. Supply either a single `token` or a `tokens` value. A bare string is rejected by the provider — the token must be wrapped in this object.
+     *
+     * @param ApnShape|null $apn
+     */
+    public function withApn(Token|array|MultipleTokens|null $apn): self
     {
         $self = clone $this;
         $self['apn'] = $apn;
@@ -354,6 +371,8 @@ final class UserProfile implements BaseModel
     }
 
     /**
+     * Expo push tokens. Supply either a single `token` or a `tokens` value.
+     *
      * @param ExpoShape|null $expo
      */
     public function withExpo(Token|array|MultipleTokens|null $expo): self

--- a/tests/Services/NotificationsTest.php
+++ b/tests/Services/NotificationsTest.php
@@ -122,19 +122,6 @@ final class NotificationsTest extends TestCase
     }
 
     #[Test]
-    public function testDuplicate(): void
-    {
-        if (UnsupportedMockTests::$skip) {
-            $this->markTestSkipped('Mock server tests are disabled');
-        }
-
-        $result = $this->client->notifications->duplicate('id');
-
-        // @phpstan-ignore-next-line method.alreadyNarrowedType
-        $this->assertInstanceOf(NotificationTemplateResponse::class, $result);
-    }
-
-    #[Test]
     public function testListVersions(): void
     {
         if (UnsupportedMockTests::$skip) {


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**1 endpoint(s) removed**

- `POST /notifications/{id}/duplicate` — Duplicate Notification Template


## What changed in this SDK

12 files changed, 105 insertions(+), 102 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                        |  2 +-
 src/Apn.php                                       | 31 +++++++++++++++++++++++++++++++
 src/Client.php                                    |  2 +-
 src/Expo.php                                      |  2 ++
 src/MultipleTokens.php                            | 26 +++++++++++++++++---------
 src/MultipleTokens/Tokens.php                     | 29 +++++++++++++++++++++++++++++
 src/ServiceContracts/NotificationsContract.php    | 13 -------------
 src/ServiceContracts/NotificationsRawContract.php | 15 ---------------
 src/Services/NotificationsRawService.php          | 25 -------------------------
 src/Services/NotificationsService.php             | 20 --------------------
 src/UserProfile.php                               | 29 ++++++++++++++++++++++++-----
 tests/Services/NotificationsTest.php              | 13 -------------
 12 files changed, 105 insertions(+), 102 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
