### PR TITLE
feat(api): document section_id and section_name on a user's topic preference

### DIFF
--- a/src/Users/Preferences/TopicPreference.php
+++ b/src/Users/Preferences/TopicPreference.php
@@ -19,6 +19,8 @@ use Courier\PreferenceStatus;
  *   topicName: string,
  *   customRouting?: list<ChannelClassification|value-of<ChannelClassification>>|null,
  *   hasCustomRouting?: bool|null,
+ *   sectionID?: string|null,
+ *   sectionName?: string|null,
  * }
  */
 final class TopicPreference implements BaseModel
@@ -73,6 +75,18 @@ final class TopicPreference implements BaseModel
     public ?bool $hasCustomRouting;
 
     /**
+     * The unique identifier of the section this topic belongs to. Always present when listing a user's preferences; omitted by the single-topic read when the topic has no resolvable section.
+     */
+    #[Optional('section_id')]
+    public ?string $sectionID;
+
+    /**
+     * The display name of the section this topic belongs to. Always present when listing a user's preferences; omitted by the single-topic read when the topic has no resolvable section.
+     */
+    #[Optional('section_name')]
+    public ?string $sectionName;
+
+    /**
      * `new TopicPreference()` is missing required properties by the API.
      *
      * To enforce required parameters use
@@ -113,6 +127,8 @@ final class TopicPreference implements BaseModel
         string $topicName,
         ?array $customRouting = null,
         ?bool $hasCustomRouting = null,
+        ?string $sectionID = null,
+        ?string $sectionName = null,
     ): self {
         $self = new self;
 
@@ -123,6 +139,8 @@ final class TopicPreference implements BaseModel
 
         null !== $customRouting && $self['customRouting'] = $customRouting;
         null !== $hasCustomRouting && $self['hasCustomRouting'] = $hasCustomRouting;
+        null !== $sectionID && $self['sectionID'] = $sectionID;
+        null !== $sectionName && $self['sectionName'] = $sectionName;
 
         return $self;
     }
@@ -196,6 +214,28 @@ final class TopicPreference implements BaseModel
     {
         $self = clone $this;
         $self['hasCustomRouting'] = $hasCustomRouting;
+
+        return $self;
+    }
+
+    /**
+     * The unique identifier of the section this topic belongs to. Always present when listing a user's preferences; omitted by the single-topic read when the topic has no resolvable section.
+     */
+    public function withSectionID(string $sectionID): self
+    {
+        $self = clone $this;
+        $self['sectionID'] = $sectionID;
+
+        return $self;
+    }
+
+    /**
+     * The display name of the section this topic belongs to. Always present when listing a user's preferences; omitted by the single-topic read when the topic has no resolvable section.
+     */
+    public function withSectionName(string $sectionName): self
+    {
+        $self = clone $this;
+        $self['sectionName'] = $sectionName;
 
         return $self;
     }


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 40 insertions(+)

<details><summary>Files</summary>

```
 src/Users/Preferences/TopicPreference.php | 40 ++++++++++++++++++++++++++++++++++++++++
 1 file changed, 40 insertions(+)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
