### PR TITLE
feat(api): add automation and journey run log endpoints

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 149
+configured_endpoints: 154

--- a/src/Automations/AutomationRunListItem.php
+++ b/src/Automations/AutomationRunListItem.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Automations;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * An Automation run as it appears in a list response.
+ *
+ * @phpstan-type AutomationRunListItemShape = array{
+ *   runID: string,
+ *   source: list<string>,
+ *   createdAt?: string|null,
+ *   status?: string|null,
+ *   templateID?: string|null,
+ * }
+ */
+final class AutomationRunListItem implements BaseModel
+{
+    /** @use SdkModel<AutomationRunListItemShape> */
+    use SdkModel;
+
+    /**
+     * A unique identifier representing the run.
+     */
+    #[Required('run_id')]
+    public string $runID;
+
+    /**
+     * Internal provenance strings describing what started the run, e.g. `invoke/<template_id>` or `segment/page/Pricing Page`. Diagnostic only — the format is unstable and should not be parsed.
+     *
+     * @var list<string> $source
+     */
+    #[Required(list: 'string')]
+    public array $source;
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    #[Optional('created_at')]
+    public ?string $createdAt;
+
+    /**
+     * The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`, `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added before.
+     */
+    #[Optional]
+    public ?string $status;
+
+    /**
+     * The id of the Automation Template this run belongs to.
+     */
+    #[Optional('template_id')]
+    public ?string $templateID;
+
+    /**
+     * `new AutomationRunListItem()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * AutomationRunListItem::with(runID: ..., source: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new AutomationRunListItem)->withRunID(...)->withSource(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string> $source
+     */
+    public static function with(
+        string $runID,
+        array $source,
+        ?string $createdAt = null,
+        ?string $status = null,
+        ?string $templateID = null,
+    ): self {
+        $self = new self;
+
+        $self['runID'] = $runID;
+        $self['source'] = $source;
+
+        null !== $createdAt && $self['createdAt'] = $createdAt;
+        null !== $status && $self['status'] = $status;
+        null !== $templateID && $self['templateID'] = $templateID;
+
+        return $self;
+    }
+
+    /**
+     * A unique identifier representing the run.
+     */
+    public function withRunID(string $runID): self
+    {
+        $self = clone $this;
+        $self['runID'] = $runID;
+
+        return $self;
+    }
+
+    /**
+     * Internal provenance strings describing what started the run, e.g. `invoke/<template_id>` or `segment/page/Pricing Page`. Diagnostic only — the format is unstable and should not be parsed.
+     *
+     * @param list<string> $source
+     */
+    public function withSource(array $source): self
+    {
+        $self = clone $this;
+        $self['source'] = $source;
+
+        return $self;
+    }
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    public function withCreatedAt(string $createdAt): self
+    {
+        $self = clone $this;
+        $self['createdAt'] = $createdAt;
+
+        return $self;
+    }
+
+    /**
+     * The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`, `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added before.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * The id of the Automation Template this run belongs to.
+     */
+    public function withTemplateID(string $templateID): self
+    {
+        $self = clone $this;
+        $self['templateID'] = $templateID;
+
+        return $self;
+    }
+}

--- a/src/Automations/AutomationRunListResponse.php
+++ b/src/Automations/AutomationRunListResponse.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Automations;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * A page of Automation runs.
+ *
+ * @phpstan-import-type AutomationRunListItemShape from \Courier\Automations\AutomationRunListItem
+ *
+ * @phpstan-type AutomationRunListResponseShape = array{
+ *   runs: list<AutomationRunListItem|AutomationRunListItemShape>,
+ *   nextCursor?: string|null,
+ * }
+ */
+final class AutomationRunListResponse implements BaseModel
+{
+    /** @use SdkModel<AutomationRunListResponseShape> */
+    use SdkModel;
+
+    /** @var list<AutomationRunListItem> $runs */
+    #[Required(list: AutomationRunListItem::class)]
+    public array $runs;
+
+    /**
+     * Pass back as `cursor` to fetch the next page. Absent on the last page.
+     */
+    #[Optional('next_cursor')]
+    public ?string $nextCursor;
+
+    /**
+     * `new AutomationRunListResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * AutomationRunListResponse::with(runs: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new AutomationRunListResponse)->withRuns(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<AutomationRunListItem|AutomationRunListItemShape> $runs
+     */
+    public static function with(array $runs, ?string $nextCursor = null): self
+    {
+        $self = new self;
+
+        $self['runs'] = $runs;
+
+        null !== $nextCursor && $self['nextCursor'] = $nextCursor;
+
+        return $self;
+    }
+
+    /**
+     * @param list<AutomationRunListItem|AutomationRunListItemShape> $runs
+     */
+    public function withRuns(array $runs): self
+    {
+        $self = clone $this;
+        $self['runs'] = $runs;
+
+        return $self;
+    }
+
+    /**
+     * Pass back as `cursor` to fetch the next page. Absent on the last page.
+     */
+    public function withNextCursor(string $nextCursor): self
+    {
+        $self = clone $this;
+        $self['nextCursor'] = $nextCursor;
+
+        return $self;
+    }
+}

--- a/src/Automations/AutomationRunStep.php
+++ b/src/Automations/AutomationRunStep.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Automations;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * One executed step of an Automation run.
+ *
+ * @phpstan-type AutomationRunStepShape = array{
+ *   action: string,
+ *   status: string,
+ *   createdAt?: string|null,
+ *   messageID?: string|null,
+ *   stepID?: string|null,
+ *   updatedAt?: string|null,
+ * }
+ */
+final class AutomationRunStep implements BaseModel
+{
+    /** @use SdkModel<AutomationRunStepShape> */
+    use SdkModel;
+
+    /**
+     * The kind of step that ran, e.g. `send`, `delay`, or `update-profile`.
+     */
+    #[Required]
+    public string $action;
+
+    /**
+     * The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`. Not an enum — new values have been added before.
+     */
+    #[Required]
+    public string $status;
+
+    /**
+     * When the step started, as an ISO 8601 timestamp.
+     */
+    #[Optional('created_at')]
+    public ?string $createdAt;
+
+    /**
+     * The message this step produced, present on send steps. Pass it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one id for the request, not one per recipient.
+     */
+    #[Optional('message_id')]
+    public ?string $messageID;
+
+    /**
+     * A unique identifier representing the step.
+     */
+    #[Optional('step_id')]
+    public ?string $stepID;
+
+    /**
+     * When the step last changed state, as an ISO 8601 timestamp.
+     */
+    #[Optional('updated_at')]
+    public ?string $updatedAt;
+
+    /**
+     * `new AutomationRunStep()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * AutomationRunStep::with(action: ..., status: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new AutomationRunStep)->withAction(...)->withStatus(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        string $action,
+        string $status,
+        ?string $createdAt = null,
+        ?string $messageID = null,
+        ?string $stepID = null,
+        ?string $updatedAt = null,
+    ): self {
+        $self = new self;
+
+        $self['action'] = $action;
+        $self['status'] = $status;
+
+        null !== $createdAt && $self['createdAt'] = $createdAt;
+        null !== $messageID && $self['messageID'] = $messageID;
+        null !== $stepID && $self['stepID'] = $stepID;
+        null !== $updatedAt && $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+
+    /**
+     * The kind of step that ran, e.g. `send`, `delay`, or `update-profile`.
+     */
+    public function withAction(string $action): self
+    {
+        $self = clone $this;
+        $self['action'] = $action;
+
+        return $self;
+    }
+
+    /**
+     * The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`. Not an enum — new values have been added before.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * When the step started, as an ISO 8601 timestamp.
+     */
+    public function withCreatedAt(string $createdAt): self
+    {
+        $self = clone $this;
+        $self['createdAt'] = $createdAt;
+
+        return $self;
+    }
+
+    /**
+     * The message this step produced, present on send steps. Pass it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one id for the request, not one per recipient.
+     */
+    public function withMessageID(string $messageID): self
+    {
+        $self = clone $this;
+        $self['messageID'] = $messageID;
+
+        return $self;
+    }
+
+    /**
+     * A unique identifier representing the step.
+     */
+    public function withStepID(string $stepID): self
+    {
+        $self = clone $this;
+        $self['stepID'] = $stepID;
+
+        return $self;
+    }
+
+    /**
+     * When the step last changed state, as an ISO 8601 timestamp.
+     */
+    public function withUpdatedAt(string $updatedAt): self
+    {
+        $self = clone $this;
+        $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+}

--- a/src/Automations/AutomationRunStepsResponse.php
+++ b/src/Automations/AutomationRunStepsResponse.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Automations;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Every step of an Automation run. Not paginated.
+ *
+ * @phpstan-import-type AutomationRunStepShape from \Courier\Automations\AutomationRunStep
+ *
+ * @phpstan-type AutomationRunStepsResponseShape = array{
+ *   steps: list<AutomationRunStep|AutomationRunStepShape>
+ * }
+ */
+final class AutomationRunStepsResponse implements BaseModel
+{
+    /** @use SdkModel<AutomationRunStepsResponseShape> */
+    use SdkModel;
+
+    /** @var list<AutomationRunStep> $steps */
+    #[Required(list: AutomationRunStep::class)]
+    public array $steps;
+
+    /**
+     * `new AutomationRunStepsResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * AutomationRunStepsResponse::with(steps: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new AutomationRunStepsResponse)->withSteps(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<AutomationRunStep|AutomationRunStepShape> $steps
+     */
+    public static function with(array $steps): self
+    {
+        $self = new self;
+
+        $self['steps'] = $steps;
+
+        return $self;
+    }
+
+    /**
+     * @param list<AutomationRunStep|AutomationRunStepShape> $steps
+     */
+    public function withSteps(array $steps): self
+    {
+        $self = clone $this;
+        $self['steps'] = $steps;
+
+        return $self;
+    }
+}

--- a/src/Automations/Runs/RunListParams.php
+++ b/src/Automations/Runs/RunListParams.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Automations\Runs;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * List runs of the workspace's v2 Automations, newest first, filtered by status, Template, or date range and paged by cursor. Journey (v3) runs are listed by `GET /journeys/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+ *
+ * @see Courier\Services\Automations\RunsService::list()
+ *
+ * @phpstan-type RunListParamsShape = array{
+ *   cursor?: string|null,
+ *   endDate?: string|null,
+ *   limit?: string|null,
+ *   startDate?: string|null,
+ *   status?: string|null,
+ *   templateID?: string|null,
+ * }
+ */
+final class RunListParams implements BaseModel
+{
+    /** @use SdkModel<RunListParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /**
+     * A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     */
+    #[Optional]
+    public ?string $cursor;
+
+    /**
+     * An inclusive upper bound on `created_at`, in the same format as `start_date`.
+     */
+    #[Optional]
+    public ?string $endDate;
+
+    /**
+     * The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     */
+    #[Optional]
+    public ?string $limit;
+
+    /**
+     * An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     */
+    #[Optional]
+    public ?string $startDate;
+
+    /**
+     * A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     */
+    #[Optional]
+    public ?string $status;
+
+    /**
+     * A comma-separated list of Automation Template ids to filter on.
+     */
+    #[Optional]
+    public ?string $templateID;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+    ): self {
+        $self = new self;
+
+        null !== $cursor && $self['cursor'] = $cursor;
+        null !== $endDate && $self['endDate'] = $endDate;
+        null !== $limit && $self['limit'] = $limit;
+        null !== $startDate && $self['startDate'] = $startDate;
+        null !== $status && $self['status'] = $status;
+        null !== $templateID && $self['templateID'] = $templateID;
+
+        return $self;
+    }
+
+    /**
+     * A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     */
+    public function withCursor(string $cursor): self
+    {
+        $self = clone $this;
+        $self['cursor'] = $cursor;
+
+        return $self;
+    }
+
+    /**
+     * An inclusive upper bound on `created_at`, in the same format as `start_date`.
+     */
+    public function withEndDate(string $endDate): self
+    {
+        $self = clone $this;
+        $self['endDate'] = $endDate;
+
+        return $self;
+    }
+
+    /**
+     * The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     */
+    public function withLimit(string $limit): self
+    {
+        $self = clone $this;
+        $self['limit'] = $limit;
+
+        return $self;
+    }
+
+    /**
+     * An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     */
+    public function withStartDate(string $startDate): self
+    {
+        $self = clone $this;
+        $self['startDate'] = $startDate;
+
+        return $self;
+    }
+
+    /**
+     * A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * A comma-separated list of Automation Template ids to filter on.
+     */
+    public function withTemplateID(string $templateID): self
+    {
+        $self = clone $this;
+        $self['templateID'] = $templateID;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyAudienceTriggerNode.php
+++ b/src/Journeys/JourneyAudienceTriggerNode.php
@@ -8,33 +8,33 @@ use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
-use Courier\Journeys\JourneySegmentTriggerNode\RequestType;
-use Courier\Journeys\JourneySegmentTriggerNode\TriggerType;
-use Courier\Journeys\JourneySegmentTriggerNode\Type;
+use Courier\Journeys\JourneyAudienceTriggerNode\TriggerType;
+use Courier\Journeys\JourneyAudienceTriggerNode\Type;
 
 /**
- * Trigger fired by a segment event (`identify`, `group`, `track`, or `page`). A trigger with no `event_id` fires on any event of its type — the only shape `identify` and `group` can take, and the one that catches a stock `analytics.page()` call.
+ * Trigger fired when a user newly matches an Audience. Leaving and re-joining the Audience re-enters the Journey. Membership is new-members-only: users already in the Audience when the Journey is published do not enter. Unlike the v2 Automations audience trigger, there is no member scope, event type, or frequency mode to configure, and `audience_id` must name one Audience — wildcards are not supported.
  *
  * @phpstan-import-type JourneyConditionsFieldVariants from \Courier\Journeys\JourneyConditionsField
  * @phpstan-import-type JourneyConditionsFieldShape from \Courier\Journeys\JourneyConditionsField
  *
- * @phpstan-type JourneySegmentTriggerNodeShape = array{
- *   requestType: RequestType|value-of<RequestType>,
+ * @phpstan-type JourneyAudienceTriggerNodeShape = array{
+ *   audienceID: string,
  *   triggerType: TriggerType|value-of<TriggerType>,
  *   type: Type|value-of<Type>,
  *   id?: string|null,
  *   conditions?: JourneyConditionsFieldShape|null,
- *   eventID?: string|null,
  * }
  */
-final class JourneySegmentTriggerNode implements BaseModel
+final class JourneyAudienceTriggerNode implements BaseModel
 {
-    /** @use SdkModel<JourneySegmentTriggerNodeShape> */
+    /** @use SdkModel<JourneyAudienceTriggerNodeShape> */
     use SdkModel;
 
-    /** @var value-of<RequestType> $requestType */
-    #[Required('request_type', enum: RequestType::class)]
-    public string $requestType;
+    /**
+     * The Audience to watch. Must name a single Audience; wildcards are not supported.
+     */
+    #[Required('audience_id')]
+    public string $audienceID;
 
     /** @var value-of<TriggerType> $triggerType */
     #[Required('trigger_type', enum: TriggerType::class)]
@@ -55,22 +55,19 @@ final class JourneySegmentTriggerNode implements BaseModel
     #[Optional(union: JourneyConditionsField::class)]
     public array|JourneyConditionGroup|JourneyConditionNestedGroup|null $conditions;
 
-    #[Optional('event_id')]
-    public ?string $eventID;
-
     /**
-     * `new JourneySegmentTriggerNode()` is missing required properties by the API.
+     * `new JourneyAudienceTriggerNode()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * JourneySegmentTriggerNode::with(requestType: ..., triggerType: ..., type: ...)
+     * JourneyAudienceTriggerNode::with(audienceID: ..., triggerType: ..., type: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new JourneySegmentTriggerNode)
-     *   ->withRequestType(...)
+     * (new JourneyAudienceTriggerNode)
+     *   ->withAudienceID(...)
      *   ->withTriggerType(...)
      *   ->withType(...)
      * ```
@@ -85,39 +82,36 @@ final class JourneySegmentTriggerNode implements BaseModel
      *
      * You must use named parameters to construct any parameters with a default value.
      *
-     * @param RequestType|value-of<RequestType> $requestType
      * @param TriggerType|value-of<TriggerType> $triggerType
      * @param Type|value-of<Type> $type
      * @param JourneyConditionsFieldShape|null $conditions
      */
     public static function with(
-        RequestType|string $requestType,
+        string $audienceID,
         TriggerType|string $triggerType,
         Type|string $type,
         ?string $id = null,
         array|JourneyConditionGroup|JourneyConditionNestedGroup|null $conditions = null,
-        ?string $eventID = null,
     ): self {
         $self = new self;
 
-        $self['requestType'] = $requestType;
+        $self['audienceID'] = $audienceID;
         $self['triggerType'] = $triggerType;
         $self['type'] = $type;
 
         null !== $id && $self['id'] = $id;
         null !== $conditions && $self['conditions'] = $conditions;
-        null !== $eventID && $self['eventID'] = $eventID;
 
         return $self;
     }
 
     /**
-     * @param RequestType|value-of<RequestType> $requestType
+     * The Audience to watch. Must name a single Audience; wildcards are not supported.
      */
-    public function withRequestType(RequestType|string $requestType): self
+    public function withAudienceID(string $audienceID): self
     {
         $self = clone $this;
-        $self['requestType'] = $requestType;
+        $self['audienceID'] = $audienceID;
 
         return $self;
     }
@@ -162,14 +156,6 @@ final class JourneySegmentTriggerNode implements BaseModel
     ): self {
         $self = clone $this;
         $self['conditions'] = $conditions;
-
-        return $self;
-    }
-
-    public function withEventID(string $eventID): self
-    {
-        $self = clone $this;
-        $self['eventID'] = $eventID;
 
         return $self;
     }

--- a/src/Journeys/JourneyAudienceTriggerNode/TriggerType.php
+++ b/src/Journeys/JourneyAudienceTriggerNode/TriggerType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\JourneyAudienceTriggerNode;
+
+enum TriggerType: string
+{
+    case AUDIENCE = 'audience';
+}

--- a/src/Journeys/JourneyAudienceTriggerNode/Type.php
+++ b/src/Journeys/JourneyAudienceTriggerNode/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\JourneyAudienceTriggerNode;
+
+enum Type: string
+{
+    case TRIGGER = 'trigger';
+}

--- a/src/Journeys/JourneyNode.php
+++ b/src/Journeys/JourneyNode.php
@@ -16,6 +16,8 @@ use Courier\Journeys\JourneyNode\JourneyBranchNode;
  *
  * @phpstan-import-type JourneyAPIInvokeTriggerNodeShape from \Courier\Journeys\JourneyAPIInvokeTriggerNode
  * @phpstan-import-type JourneySegmentTriggerNodeShape from \Courier\Journeys\JourneySegmentTriggerNode
+ * @phpstan-import-type JourneyAudienceTriggerNodeShape from \Courier\Journeys\JourneyAudienceTriggerNode
+ * @phpstan-import-type JourneyWebhookTriggerNodeShape from \Courier\Journeys\JourneyWebhookTriggerNode
  * @phpstan-import-type JourneySendNodeShape from \Courier\Journeys\JourneySendNode
  * @phpstan-import-type JourneyDelayDurationNodeShape from \Courier\Journeys\JourneyDelayDurationNode
  * @phpstan-import-type JourneyDelayUntilNodeShape from \Courier\Journeys\JourneyDelayUntilNode
@@ -29,8 +31,8 @@ use Courier\Journeys\JourneyNode\JourneyBranchNode;
  * @phpstan-import-type JourneyExitNodeShape from \Courier\Journeys\JourneyExitNode
  * @phpstan-import-type JourneyBranchNodeShape from \Courier\Journeys\JourneyNode\JourneyBranchNode
  *
- * @phpstan-type JourneyNodeVariants = JourneyAPIInvokeTriggerNode|JourneySegmentTriggerNode|JourneySendNode|JourneyDelayDurationNode|JourneyDelayUntilNode|JourneyFetchGetDeleteNode|JourneyFetchPostPutNode|JourneyAINode|JourneyThrottleStaticNode|JourneyThrottleDynamicNode|JourneyBatchNode|JourneyAddToDigestNode|JourneyExitNode|JourneyBranchNode
- * @phpstan-type JourneyNodeShape = JourneyNodeVariants|JourneyAPIInvokeTriggerNodeShape|JourneySegmentTriggerNodeShape|JourneySendNodeShape|JourneyDelayDurationNodeShape|JourneyDelayUntilNodeShape|JourneyFetchGetDeleteNodeShape|JourneyFetchPostPutNodeShape|JourneyAINodeShape|JourneyThrottleStaticNodeShape|JourneyThrottleDynamicNodeShape|JourneyBatchNodeShape|JourneyAddToDigestNodeShape|JourneyExitNodeShape|JourneyBranchNodeShape
+ * @phpstan-type JourneyNodeVariants = JourneyAPIInvokeTriggerNode|JourneySegmentTriggerNode|JourneyAudienceTriggerNode|JourneyWebhookTriggerNode|JourneySendNode|JourneyDelayDurationNode|JourneyDelayUntilNode|JourneyFetchGetDeleteNode|JourneyFetchPostPutNode|JourneyAINode|JourneyThrottleStaticNode|JourneyThrottleDynamicNode|JourneyBatchNode|JourneyAddToDigestNode|JourneyExitNode|JourneyBranchNode
+ * @phpstan-type JourneyNodeShape = JourneyNodeVariants|JourneyAPIInvokeTriggerNodeShape|JourneySegmentTriggerNodeShape|JourneyAudienceTriggerNodeShape|JourneyWebhookTriggerNodeShape|JourneySendNodeShape|JourneyDelayDurationNodeShape|JourneyDelayUntilNodeShape|JourneyFetchGetDeleteNodeShape|JourneyFetchPostPutNodeShape|JourneyAINodeShape|JourneyThrottleStaticNodeShape|JourneyThrottleDynamicNodeShape|JourneyBatchNodeShape|JourneyAddToDigestNodeShape|JourneyExitNodeShape|JourneyBranchNodeShape
  */
 final class JourneyNode implements ConverterSource
 {
@@ -44,6 +46,8 @@ final class JourneyNode implements ConverterSource
         return [
             JourneyAPIInvokeTriggerNode::class,
             JourneySegmentTriggerNode::class,
+            JourneyAudienceTriggerNode::class,
+            JourneyWebhookTriggerNode::class,
             JourneySendNode::class,
             JourneyDelayDurationNode::class,
             JourneyDelayUntilNode::class,

--- a/src/Journeys/JourneyRun.php
+++ b/src/Journeys/JourneyRun.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * One run of a Journey. `status` and `created_at` are absent on a small number of legacy runs stored without them.
+ *
+ * @phpstan-type JourneyRunShape = array{
+ *   runID: string,
+ *   source: list<string>,
+ *   createdAt?: string|null,
+ *   status?: string|null,
+ *   templateID?: string|null,
+ *   updatedAt?: string|null,
+ * }
+ */
+final class JourneyRun implements BaseModel
+{
+    /** @use SdkModel<JourneyRunShape> */
+    use SdkModel;
+
+    /**
+     * A unique identifier representing the run.
+     */
+    #[Required('run_id')]
+    public string $runID;
+
+    /**
+     * Internal provenance strings describing what started the run, e.g. `invoke/<journey_id>` or `segment/page/Pricing Page`. Diagnostic only — the format is unstable and should not be parsed.
+     *
+     * @var list<string> $source
+     */
+    #[Required(list: 'string')]
+    public array $source;
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    #[Optional('created_at')]
+    public ?string $createdAt;
+
+    /**
+     * The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`, `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added before.
+     */
+    #[Optional]
+    public ?string $status;
+
+    /**
+     * The id of the Journey this run belongs to.
+     */
+    #[Optional('template_id')]
+    public ?string $templateID;
+
+    /**
+     * When the run last changed state, as an ISO 8601 timestamp.
+     */
+    #[Optional('updated_at')]
+    public ?string $updatedAt;
+
+    /**
+     * `new JourneyRun()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRun::with(runID: ..., source: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRun)->withRunID(...)->withSource(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string> $source
+     */
+    public static function with(
+        string $runID,
+        array $source,
+        ?string $createdAt = null,
+        ?string $status = null,
+        ?string $templateID = null,
+        ?string $updatedAt = null,
+    ): self {
+        $self = new self;
+
+        $self['runID'] = $runID;
+        $self['source'] = $source;
+
+        null !== $createdAt && $self['createdAt'] = $createdAt;
+        null !== $status && $self['status'] = $status;
+        null !== $templateID && $self['templateID'] = $templateID;
+        null !== $updatedAt && $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+
+    /**
+     * A unique identifier representing the run.
+     */
+    public function withRunID(string $runID): self
+    {
+        $self = clone $this;
+        $self['runID'] = $runID;
+
+        return $self;
+    }
+
+    /**
+     * Internal provenance strings describing what started the run, e.g. `invoke/<journey_id>` or `segment/page/Pricing Page`. Diagnostic only — the format is unstable and should not be parsed.
+     *
+     * @param list<string> $source
+     */
+    public function withSource(array $source): self
+    {
+        $self = clone $this;
+        $self['source'] = $source;
+
+        return $self;
+    }
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    public function withCreatedAt(string $createdAt): self
+    {
+        $self = clone $this;
+        $self['createdAt'] = $createdAt;
+
+        return $self;
+    }
+
+    /**
+     * The state of the run: `PROCESSING`, `PROCESSED`, `WAITING`, `CANCELED`, `ERROR`, `THROTTLED`, or `NOT PROCESSED`. Not an enum — new values have been added before.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * The id of the Journey this run belongs to.
+     */
+    public function withTemplateID(string $templateID): self
+    {
+        $self = clone $this;
+        $self['templateID'] = $templateID;
+
+        return $self;
+    }
+
+    /**
+     * When the run last changed state, as an ISO 8601 timestamp.
+     */
+    public function withUpdatedAt(string $updatedAt): self
+    {
+        $self = clone $this;
+        $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyRunListItem.php
+++ b/src/Journeys/JourneyRunListItem.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * A Journey run as it appears in a list response, without `updated_at`.
+ *
+ * @phpstan-type JourneyRunListItemShape = array{
+ *   runID: string,
+ *   source: list<string>,
+ *   createdAt?: string|null,
+ *   status?: string|null,
+ *   templateID?: string|null,
+ * }
+ */
+final class JourneyRunListItem implements BaseModel
+{
+    /** @use SdkModel<JourneyRunListItemShape> */
+    use SdkModel;
+
+    /**
+     * A unique identifier representing the run.
+     */
+    #[Required('run_id')]
+    public string $runID;
+
+    /**
+     * Internal provenance strings describing what started the run. Diagnostic only.
+     *
+     * @var list<string> $source
+     */
+    #[Required(list: 'string')]
+    public array $source;
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    #[Optional('created_at')]
+    public ?string $createdAt;
+
+    /**
+     * The state of the run. See `JourneyRun.status` for the values it takes.
+     */
+    #[Optional]
+    public ?string $status;
+
+    /**
+     * The id of the Journey this run belongs to.
+     */
+    #[Optional('template_id')]
+    public ?string $templateID;
+
+    /**
+     * `new JourneyRunListItem()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRunListItem::with(runID: ..., source: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRunListItem)->withRunID(...)->withSource(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string> $source
+     */
+    public static function with(
+        string $runID,
+        array $source,
+        ?string $createdAt = null,
+        ?string $status = null,
+        ?string $templateID = null,
+    ): self {
+        $self = new self;
+
+        $self['runID'] = $runID;
+        $self['source'] = $source;
+
+        null !== $createdAt && $self['createdAt'] = $createdAt;
+        null !== $status && $self['status'] = $status;
+        null !== $templateID && $self['templateID'] = $templateID;
+
+        return $self;
+    }
+
+    /**
+     * A unique identifier representing the run.
+     */
+    public function withRunID(string $runID): self
+    {
+        $self = clone $this;
+        $self['runID'] = $runID;
+
+        return $self;
+    }
+
+    /**
+     * Internal provenance strings describing what started the run. Diagnostic only.
+     *
+     * @param list<string> $source
+     */
+    public function withSource(array $source): self
+    {
+        $self = clone $this;
+        $self['source'] = $source;
+
+        return $self;
+    }
+
+    /**
+     * When the run started, as an ISO 8601 timestamp.
+     */
+    public function withCreatedAt(string $createdAt): self
+    {
+        $self = clone $this;
+        $self['createdAt'] = $createdAt;
+
+        return $self;
+    }
+
+    /**
+     * The state of the run. See `JourneyRun.status` for the values it takes.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * The id of the Journey this run belongs to.
+     */
+    public function withTemplateID(string $templateID): self
+    {
+        $self = clone $this;
+        $self['templateID'] = $templateID;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyRunListResponse.php
+++ b/src/Journeys/JourneyRunListResponse.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * A page of Journey runs.
+ *
+ * @phpstan-import-type JourneyRunListItemShape from \Courier\Journeys\JourneyRunListItem
+ *
+ * @phpstan-type JourneyRunListResponseShape = array{
+ *   runs: list<JourneyRunListItem|JourneyRunListItemShape>,
+ *   nextCursor?: string|null,
+ *   prevCursor?: string|null,
+ * }
+ */
+final class JourneyRunListResponse implements BaseModel
+{
+    /** @use SdkModel<JourneyRunListResponseShape> */
+    use SdkModel;
+
+    /** @var list<JourneyRunListItem> $runs */
+    #[Required(list: JourneyRunListItem::class)]
+    public array $runs;
+
+    /**
+     * Pass back as `cursor` to fetch the next page. Absent on the last page.
+     */
+    #[Optional('next_cursor')]
+    public ?string $nextCursor;
+
+    /**
+     * Pass back as `cursor` to fetch the previous page. Absent on the first page.
+     */
+    #[Optional('prev_cursor')]
+    public ?string $prevCursor;
+
+    /**
+     * `new JourneyRunListResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRunListResponse::with(runs: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRunListResponse)->withRuns(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<JourneyRunListItem|JourneyRunListItemShape> $runs
+     */
+    public static function with(
+        array $runs,
+        ?string $nextCursor = null,
+        ?string $prevCursor = null
+    ): self {
+        $self = new self;
+
+        $self['runs'] = $runs;
+
+        null !== $nextCursor && $self['nextCursor'] = $nextCursor;
+        null !== $prevCursor && $self['prevCursor'] = $prevCursor;
+
+        return $self;
+    }
+
+    /**
+     * @param list<JourneyRunListItem|JourneyRunListItemShape> $runs
+     */
+    public function withRuns(array $runs): self
+    {
+        $self = clone $this;
+        $self['runs'] = $runs;
+
+        return $self;
+    }
+
+    /**
+     * Pass back as `cursor` to fetch the next page. Absent on the last page.
+     */
+    public function withNextCursor(string $nextCursor): self
+    {
+        $self = clone $this;
+        $self['nextCursor'] = $nextCursor;
+
+        return $self;
+    }
+
+    /**
+     * Pass back as `cursor` to fetch the previous page. Absent on the first page.
+     */
+    public function withPrevCursor(string $prevCursor): self
+    {
+        $self = clone $this;
+        $self['prevCursor'] = $prevCursor;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyRunResponse.php
+++ b/src/Journeys/JourneyRunResponse.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * A single Journey run.
+ *
+ * @phpstan-import-type JourneyRunShape from \Courier\Journeys\JourneyRun
+ *
+ * @phpstan-type JourneyRunResponseShape = array{run: JourneyRun|JourneyRunShape}
+ */
+final class JourneyRunResponse implements BaseModel
+{
+    /** @use SdkModel<JourneyRunResponseShape> */
+    use SdkModel;
+
+    /**
+     * One run of a Journey. `status` and `created_at` are absent on a small number of legacy runs stored without them.
+     */
+    #[Required]
+    public JourneyRun $run;
+
+    /**
+     * `new JourneyRunResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRunResponse::with(run: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRunResponse)->withRun(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param JourneyRun|JourneyRunShape $run
+     */
+    public static function with(JourneyRun|array $run): self
+    {
+        $self = new self;
+
+        $self['run'] = $run;
+
+        return $self;
+    }
+
+    /**
+     * One run of a Journey. `status` and `created_at` are absent on a small number of legacy runs stored without them.
+     *
+     * @param JourneyRun|JourneyRunShape $run
+     */
+    public function withRun(JourneyRun|array $run): self
+    {
+        $self = clone $this;
+        $self['run'] = $run;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyRunStep.php
+++ b/src/Journeys/JourneyRunStep.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * One executed node of a Journey run. `node_id` is the id of the node in the published Journey, so a step maps directly onto the Journey graph.
+ *
+ * @phpstan-type JourneyRunStepShape = array{
+ *   action: string,
+ *   status: string,
+ *   createdAt?: string|null,
+ *   messageID?: string|null,
+ *   nodeID?: string|null,
+ *   updatedAt?: string|null,
+ * }
+ */
+final class JourneyRunStep implements BaseModel
+{
+    /** @use SdkModel<JourneyRunStepShape> */
+    use SdkModel;
+
+    /**
+     * The kind of node that ran, e.g. `send`, `delay`, or `exit`.
+     */
+    #[Required]
+    public string $action;
+
+    /**
+     * The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`. Not an enum — new values have been added before.
+     */
+    #[Required]
+    public string $status;
+
+    /**
+     * When the step started, as an ISO 8601 timestamp.
+     */
+    #[Optional('created_at')]
+    public ?string $createdAt;
+
+    /**
+     * The message this step produced, present on send steps. Pass it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one id for the request, not one per recipient.
+     */
+    #[Optional('message_id')]
+    public ?string $messageID;
+
+    /**
+     * The id of the node in the published Journey that this step executed.
+     */
+    #[Optional('node_id')]
+    public ?string $nodeID;
+
+    /**
+     * When the step last changed state, as an ISO 8601 timestamp.
+     */
+    #[Optional('updated_at')]
+    public ?string $updatedAt;
+
+    /**
+     * `new JourneyRunStep()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRunStep::with(action: ..., status: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRunStep)->withAction(...)->withStatus(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        string $action,
+        string $status,
+        ?string $createdAt = null,
+        ?string $messageID = null,
+        ?string $nodeID = null,
+        ?string $updatedAt = null,
+    ): self {
+        $self = new self;
+
+        $self['action'] = $action;
+        $self['status'] = $status;
+
+        null !== $createdAt && $self['createdAt'] = $createdAt;
+        null !== $messageID && $self['messageID'] = $messageID;
+        null !== $nodeID && $self['nodeID'] = $nodeID;
+        null !== $updatedAt && $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+
+    /**
+     * The kind of node that ran, e.g. `send`, `delay`, or `exit`.
+     */
+    public function withAction(string $action): self
+    {
+        $self = clone $this;
+        $self['action'] = $action;
+
+        return $self;
+    }
+
+    /**
+     * The state of the step: the seven run statuses, plus `SKIPPED` and `COMPUTING`. Not an enum — new values have been added before.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * When the step started, as an ISO 8601 timestamp.
+     */
+    public function withCreatedAt(string $createdAt): self
+    {
+        $self = clone $this;
+        $self['createdAt'] = $createdAt;
+
+        return $self;
+    }
+
+    /**
+     * The message this step produced, present on send steps. Pass it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one id for the request, not one per recipient.
+     */
+    public function withMessageID(string $messageID): self
+    {
+        $self = clone $this;
+        $self['messageID'] = $messageID;
+
+        return $self;
+    }
+
+    /**
+     * The id of the node in the published Journey that this step executed.
+     */
+    public function withNodeID(string $nodeID): self
+    {
+        $self = clone $this;
+        $self['nodeID'] = $nodeID;
+
+        return $self;
+    }
+
+    /**
+     * When the step last changed state, as an ISO 8601 timestamp.
+     */
+    public function withUpdatedAt(string $updatedAt): self
+    {
+        $self = clone $this;
+        $self['updatedAt'] = $updatedAt;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneyRunStepsResponse.php
+++ b/src/Journeys/JourneyRunStepsResponse.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Every step of a Journey run. Not paginated.
+ *
+ * @phpstan-import-type JourneyRunStepShape from \Courier\Journeys\JourneyRunStep
+ *
+ * @phpstan-type JourneyRunStepsResponseShape = array{
+ *   steps: list<JourneyRunStep|JourneyRunStepShape>
+ * }
+ */
+final class JourneyRunStepsResponse implements BaseModel
+{
+    /** @use SdkModel<JourneyRunStepsResponseShape> */
+    use SdkModel;
+
+    /** @var list<JourneyRunStep> $steps */
+    #[Required(list: JourneyRunStep::class)]
+    public array $steps;
+
+    /**
+     * `new JourneyRunStepsResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneyRunStepsResponse::with(steps: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneyRunStepsResponse)->withSteps(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<JourneyRunStep|JourneyRunStepShape> $steps
+     */
+    public static function with(array $steps): self
+    {
+        $self = new self;
+
+        $self['steps'] = $steps;
+
+        return $self;
+    }
+
+    /**
+     * @param list<JourneyRunStep|JourneyRunStepShape> $steps
+     */
+    public function withSteps(array $steps): self
+    {
+        $self = clone $this;
+        $self['steps'] = $steps;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneySegmentTriggerNode/RequestType.php
+++ b/src/Journeys/JourneySegmentTriggerNode/RequestType.php
@@ -11,4 +11,6 @@ enum RequestType: string
     case GROUP = 'group';
 
     case TRACK = 'track';
+
+    case PAGE = 'page';
 }

--- a/src/Journeys/JourneyWebhookTriggerNode.php
+++ b/src/Journeys/JourneyWebhookTriggerNode.php
@@ -8,18 +8,17 @@ use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
-use Courier\Journeys\JourneySegmentTriggerNode\RequestType;
-use Courier\Journeys\JourneySegmentTriggerNode\TriggerType;
-use Courier\Journeys\JourneySegmentTriggerNode\Type;
+use Courier\Journeys\JourneyWebhookTriggerNode\TriggerType;
+use Courier\Journeys\JourneyWebhookTriggerNode\Type;
 
 /**
- * Trigger fired by a segment event (`identify`, `group`, `track`, or `page`). A trigger with no `event_id` fires on any event of its type — the only shape `identify` and `group` can take, and the one that catches a stock `analytics.page()` call.
+ * Trigger fired when an external system POSTs to the webhook URL minted for `event_source`. Narrow it to one event with `event_id`, or omit `event_id` to accept every event delivered to the URL.
  *
  * @phpstan-import-type JourneyConditionsFieldVariants from \Courier\Journeys\JourneyConditionsField
  * @phpstan-import-type JourneyConditionsFieldShape from \Courier\Journeys\JourneyConditionsField
  *
- * @phpstan-type JourneySegmentTriggerNodeShape = array{
- *   requestType: RequestType|value-of<RequestType>,
+ * @phpstan-type JourneyWebhookTriggerNodeShape = array{
+ *   eventSource: string,
  *   triggerType: TriggerType|value-of<TriggerType>,
  *   type: Type|value-of<Type>,
  *   id?: string|null,
@@ -27,14 +26,16 @@ use Courier\Journeys\JourneySegmentTriggerNode\Type;
  *   eventID?: string|null,
  * }
  */
-final class JourneySegmentTriggerNode implements BaseModel
+final class JourneyWebhookTriggerNode implements BaseModel
 {
-    /** @use SdkModel<JourneySegmentTriggerNodeShape> */
+    /** @use SdkModel<JourneyWebhookTriggerNodeShape> */
     use SdkModel;
 
-    /** @var value-of<RequestType> $requestType */
-    #[Required('request_type', enum: RequestType::class)]
-    public string $requestType;
+    /**
+     * The provider key the webhook URL is minted for. Required, and must not contain a forward slash.
+     */
+    #[Required('event_source')]
+    public string $eventSource;
 
     /** @var value-of<TriggerType> $triggerType */
     #[Required('trigger_type', enum: TriggerType::class)]
@@ -55,22 +56,25 @@ final class JourneySegmentTriggerNode implements BaseModel
     #[Optional(union: JourneyConditionsField::class)]
     public array|JourneyConditionGroup|JourneyConditionNestedGroup|null $conditions;
 
+    /**
+     * An optional event filter, matched against the payload's `event` field. A sender that supplies no `event` matches the literal `custom`. Must not contain a forward slash. Omit to accept every event delivered to the URL.
+     */
     #[Optional('event_id')]
     public ?string $eventID;
 
     /**
-     * `new JourneySegmentTriggerNode()` is missing required properties by the API.
+     * `new JourneyWebhookTriggerNode()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * JourneySegmentTriggerNode::with(requestType: ..., triggerType: ..., type: ...)
+     * JourneyWebhookTriggerNode::with(eventSource: ..., triggerType: ..., type: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new JourneySegmentTriggerNode)
-     *   ->withRequestType(...)
+     * (new JourneyWebhookTriggerNode)
+     *   ->withEventSource(...)
      *   ->withTriggerType(...)
      *   ->withType(...)
      * ```
@@ -85,13 +89,12 @@ final class JourneySegmentTriggerNode implements BaseModel
      *
      * You must use named parameters to construct any parameters with a default value.
      *
-     * @param RequestType|value-of<RequestType> $requestType
      * @param TriggerType|value-of<TriggerType> $triggerType
      * @param Type|value-of<Type> $type
      * @param JourneyConditionsFieldShape|null $conditions
      */
     public static function with(
-        RequestType|string $requestType,
+        string $eventSource,
         TriggerType|string $triggerType,
         Type|string $type,
         ?string $id = null,
@@ -100,7 +103,7 @@ final class JourneySegmentTriggerNode implements BaseModel
     ): self {
         $self = new self;
 
-        $self['requestType'] = $requestType;
+        $self['eventSource'] = $eventSource;
         $self['triggerType'] = $triggerType;
         $self['type'] = $type;
 
@@ -112,12 +115,12 @@ final class JourneySegmentTriggerNode implements BaseModel
     }
 
     /**
-     * @param RequestType|value-of<RequestType> $requestType
+     * The provider key the webhook URL is minted for. Required, and must not contain a forward slash.
      */
-    public function withRequestType(RequestType|string $requestType): self
+    public function withEventSource(string $eventSource): self
     {
         $self = clone $this;
-        $self['requestType'] = $requestType;
+        $self['eventSource'] = $eventSource;
 
         return $self;
     }
@@ -166,6 +169,9 @@ final class JourneySegmentTriggerNode implements BaseModel
         return $self;
     }
 
+    /**
+     * An optional event filter, matched against the payload's `event` field. A sender that supplies no `event` matches the literal `custom`. Must not contain a forward slash. Omit to accept every event delivered to the URL.
+     */
     public function withEventID(string $eventID): self
     {
         $self = clone $this;

--- a/src/Journeys/JourneyWebhookTriggerNode/TriggerType.php
+++ b/src/Journeys/JourneyWebhookTriggerNode/TriggerType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\JourneyWebhookTriggerNode;
+
+enum TriggerType: string
+{
+    case WEBHOOK = 'webhook';
+}

--- a/src/Journeys/JourneyWebhookTriggerNode/Type.php
+++ b/src/Journeys/JourneyWebhookTriggerNode/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\JourneyWebhookTriggerNode;
+
+enum Type: string
+{
+    case TRIGGER = 'trigger';
+}

--- a/src/Journeys/Runs/RunListParams.php
+++ b/src/Journeys/Runs/RunListParams.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\Runs;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * List runs of the workspace's Journeys, newest first, filtered by status, Journey, or date range and paged by cursor. Runs of v2 Automations are listed by `GET /automations/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+ *
+ * @see Courier\Services\Journeys\RunsService::list()
+ *
+ * @phpstan-type RunListParamsShape = array{
+ *   cursor?: string|null,
+ *   endDate?: string|null,
+ *   limit?: string|null,
+ *   startDate?: string|null,
+ *   status?: string|null,
+ *   templateID?: string|null,
+ * }
+ */
+final class RunListParams implements BaseModel
+{
+    /** @use SdkModel<RunListParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /**
+     * A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     */
+    #[Optional]
+    public ?string $cursor;
+
+    /**
+     * An inclusive upper bound on `created_at`, in the same format as `start_date`.
+     */
+    #[Optional]
+    public ?string $endDate;
+
+    /**
+     * The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     */
+    #[Optional]
+    public ?string $limit;
+
+    /**
+     * An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     */
+    #[Optional]
+    public ?string $startDate;
+
+    /**
+     * A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     */
+    #[Optional]
+    public ?string $status;
+
+    /**
+     * A comma-separated list of Journey ids to filter on.
+     */
+    #[Optional]
+    public ?string $templateID;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+    ): self {
+        $self = new self;
+
+        null !== $cursor && $self['cursor'] = $cursor;
+        null !== $endDate && $self['endDate'] = $endDate;
+        null !== $limit && $self['limit'] = $limit;
+        null !== $startDate && $self['startDate'] = $startDate;
+        null !== $status && $self['status'] = $status;
+        null !== $templateID && $self['templateID'] = $templateID;
+
+        return $self;
+    }
+
+    /**
+     * A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     */
+    public function withCursor(string $cursor): self
+    {
+        $self = clone $this;
+        $self['cursor'] = $cursor;
+
+        return $self;
+    }
+
+    /**
+     * An inclusive upper bound on `created_at`, in the same format as `start_date`.
+     */
+    public function withEndDate(string $endDate): self
+    {
+        $self = clone $this;
+        $self['endDate'] = $endDate;
+
+        return $self;
+    }
+
+    /**
+     * The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     */
+    public function withLimit(string $limit): self
+    {
+        $self = clone $this;
+        $self['limit'] = $limit;
+
+        return $self;
+    }
+
+    /**
+     * An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     */
+    public function withStartDate(string $startDate): self
+    {
+        $self = clone $this;
+        $self['startDate'] = $startDate;
+
+        return $self;
+    }
+
+    /**
+     * A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     */
+    public function withStatus(string $status): self
+    {
+        $self = clone $this;
+        $self['status'] = $status;
+
+        return $self;
+    }
+
+    /**
+     * A comma-separated list of Journey ids to filter on.
+     */
+    public function withTemplateID(string $templateID): self
+    {
+        $self = clone $this;
+        $self['templateID'] = $templateID;
+
+        return $self;
+    }
+}

--- a/src/ServiceContracts/Automations/RunsContract.php
+++ b/src/ServiceContracts/Automations/RunsContract.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts\Automations;
+
+use Courier\Automations\AutomationRunListResponse;
+use Courier\Automations\AutomationRunStepsResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface RunsContract
+{
+    /**
+     * @api
+     *
+     * @param string $cursor A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     * @param string $endDate an inclusive upper bound on `created_at`, in the same format as `start_date`
+     * @param string $limit The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     * @param string $startDate An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     * @param string $status A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     * @param string $templateID a comma-separated list of Automation Template ids to filter on
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function list(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): AutomationRunListResponse;
+
+    /**
+     * @api
+     *
+     * @param string $id a unique identifier representing the Automation run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $id,
+        RequestOptions|array|null $requestOptions = null
+    ): AutomationRunStepsResponse;
+}

--- a/src/ServiceContracts/Automations/RunsRawContract.php
+++ b/src/ServiceContracts/Automations/RunsRawContract.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts\Automations;
+
+use Courier\Automations\AutomationRunListResponse;
+use Courier\Automations\AutomationRunStepsResponse;
+use Courier\Automations\Runs\RunListParams;
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface RunsRawContract
+{
+    /**
+     * @api
+     *
+     * @param array<string,mixed>|RunListParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<AutomationRunListResponse>
+     *
+     * @throws APIException
+     */
+    public function list(
+        array|RunListParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $id a unique identifier representing the Automation run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<AutomationRunStepsResponse>
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $id,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+}

--- a/src/ServiceContracts/Journeys/RunsContract.php
+++ b/src/ServiceContracts/Journeys/RunsContract.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts\Journeys;
+
+use Courier\Core\Exceptions\APIException;
+use Courier\Journeys\JourneyRunListResponse;
+use Courier\Journeys\JourneyRunResponse;
+use Courier\Journeys\JourneyRunStepsResponse;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface RunsContract
+{
+    /**
+     * @api
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function retrieve(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): JourneyRunResponse;
+
+    /**
+     * @api
+     *
+     * @param string $cursor A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     * @param string $endDate an inclusive upper bound on `created_at`, in the same format as `start_date`
+     * @param string $limit The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     * @param string $startDate An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     * @param string $status A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     * @param string $templateID a comma-separated list of Journey ids to filter on
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function list(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): JourneyRunListResponse;
+
+    /**
+     * @api
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): JourneyRunStepsResponse;
+}

--- a/src/ServiceContracts/Journeys/RunsRawContract.php
+++ b/src/ServiceContracts/Journeys/RunsRawContract.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ServiceContracts\Journeys;
+
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\Journeys\JourneyRunListResponse;
+use Courier\Journeys\JourneyRunResponse;
+use Courier\Journeys\JourneyRunStepsResponse;
+use Courier\Journeys\Runs\RunListParams;
+use Courier\RequestOptions;
+
+/**
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+interface RunsRawContract
+{
+    /**
+     * @api
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunResponse>
+     *
+     * @throws APIException
+     */
+    public function retrieve(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param array<string,mixed>|RunListParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunListResponse>
+     *
+     * @throws APIException
+     */
+    public function list(
+        array|RunListParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunStepsResponse>
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+}

--- a/src/Services/Automations/RunsRawService.php
+++ b/src/Services/Automations/RunsRawService.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services\Automations;
+
+use Courier\Automations\AutomationRunListResponse;
+use Courier\Automations\AutomationRunStepsResponse;
+use Courier\Automations\Runs\RunListParams;
+use Courier\Client;
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\Core\Util;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\Automations\RunsRawContract;
+
+/**
+ * Invoke a stored automation template or an ad hoc automation defined in the request.
+ *
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class RunsRawService implements RunsRawContract
+{
+    // @phpstan-ignore-next-line
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client) {}
+
+    /**
+     * @api
+     *
+     * List runs of the workspace's v2 Automations, newest first, filtered by status, Template, or date range and paged by cursor. Journey (v3) runs are listed by `GET /journeys/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+     *
+     * @param array{
+     *   cursor?: string,
+     *   endDate?: string,
+     *   limit?: string,
+     *   startDate?: string,
+     *   status?: string,
+     *   templateID?: string,
+     * }|RunListParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<AutomationRunListResponse>
+     *
+     * @throws APIException
+     */
+    public function list(
+        array|RunListParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = RunListParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: 'automations/runs',
+            query: Util::array_transform_keys(
+                $parsed,
+                [
+                    'endDate' => 'end_date',
+                    'startDate' => 'start_date',
+                    'templateID' => 'template_id',
+                ],
+            ),
+            options: $options,
+            convert: AutomationRunListResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * List the per-step state of one Automation run, in full — this endpoint is not paginated. `message_id` is present on send steps that produced a message; follow it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one `message_id` for the request, not one per recipient.
+     *
+     * @param string $id a unique identifier representing the Automation run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<AutomationRunStepsResponse>
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $id,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse {
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['automations/runs/%1$s/steps', $id],
+            options: $requestOptions,
+            convert: AutomationRunStepsResponse::class,
+        );
+    }
+}

--- a/src/Services/Automations/RunsService.php
+++ b/src/Services/Automations/RunsService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services\Automations;
+
+use Courier\Automations\AutomationRunListResponse;
+use Courier\Automations\AutomationRunStepsResponse;
+use Courier\Client;
+use Courier\Core\Exceptions\APIException;
+use Courier\Core\Util;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\Automations\RunsContract;
+
+/**
+ * Invoke a stored automation template or an ad hoc automation defined in the request.
+ *
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class RunsService implements RunsContract
+{
+    /**
+     * @api
+     */
+    public RunsRawService $raw;
+
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client)
+    {
+        $this->raw = new RunsRawService($client);
+    }
+
+    /**
+     * @api
+     *
+     * List runs of the workspace's v2 Automations, newest first, filtered by status, Template, or date range and paged by cursor. Journey (v3) runs are listed by `GET /journeys/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+     *
+     * @param string $cursor A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     * @param string $endDate an inclusive upper bound on `created_at`, in the same format as `start_date`
+     * @param string $limit The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     * @param string $startDate An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     * @param string $status A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     * @param string $templateID a comma-separated list of Automation Template ids to filter on
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function list(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): AutomationRunListResponse {
+        $params = Util::removeNulls(
+            [
+                'cursor' => $cursor,
+                'endDate' => $endDate,
+                'limit' => $limit,
+                'startDate' => $startDate,
+                'status' => $status,
+                'templateID' => $templateID,
+            ],
+        );
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->list(params: $params, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * List the per-step state of one Automation run, in full — this endpoint is not paginated. `message_id` is present on send steps that produced a message; follow it to `GET /messages/{message_id}` for delivery status. A send to a List or an Audience yields one `message_id` for the request, not one per recipient.
+     *
+     * @param string $id a unique identifier representing the Automation run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $id,
+        RequestOptions|array|null $requestOptions = null
+    ): AutomationRunStepsResponse {
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->listSteps($id, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+}

--- a/src/Services/AutomationsService.php
+++ b/src/Services/AutomationsService.php
@@ -12,6 +12,7 @@ use Courier\Core\Util;
 use Courier\RequestOptions;
 use Courier\ServiceContracts\AutomationsContract;
 use Courier\Services\Automations\InvokeService;
+use Courier\Services\Automations\RunsService;
 
 /**
  * Invoke a stored automation template or an ad hoc automation defined in the request.
@@ -31,12 +32,18 @@ final class AutomationsService implements AutomationsContract
     public InvokeService $invoke;
 
     /**
+     * @api
+     */
+    public RunsService $runs;
+
+    /**
      * @internal
      */
     public function __construct(private Client $client)
     {
         $this->raw = new AutomationsRawService($client);
         $this->invoke = new InvokeService($client);
+        $this->runs = new RunsService($client);
     }
 
     /**

--- a/src/Services/Journeys/RunsRawService.php
+++ b/src/Services/Journeys/RunsRawService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services\Journeys;
+
+use Courier\Client;
+use Courier\Core\Contracts\BaseResponse;
+use Courier\Core\Exceptions\APIException;
+use Courier\Core\Util;
+use Courier\Journeys\JourneyRunListResponse;
+use Courier\Journeys\JourneyRunResponse;
+use Courier\Journeys\JourneyRunStepsResponse;
+use Courier\Journeys\Runs\RunListParams;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\Journeys\RunsRawContract;
+
+/**
+ * Build, version, publish, invoke, and cancel multi-step notification workflows, along with the templates scoped to them.
+ *
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class RunsRawService implements RunsRawContract
+{
+    // @phpstan-ignore-next-line
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client) {}
+
+    /**
+     * @api
+     *
+     * Fetch one Journey run by id. Returns `404` for an unknown run, a run belonging to another workspace, a run past the 95-day retention window, or an Automation run id — the same body in every case, so the response never reveals whether a run exists elsewhere.
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunResponse>
+     *
+     * @throws APIException
+     */
+    public function retrieve(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse {
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['journeys/runs/%1$s', $runID],
+            options: $requestOptions,
+            convert: JourneyRunResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * List runs of the workspace's Journeys, newest first, filtered by status, Journey, or date range and paged by cursor. Runs of v2 Automations are listed by `GET /automations/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+     *
+     * @param array{
+     *   cursor?: string,
+     *   endDate?: string,
+     *   limit?: string,
+     *   startDate?: string,
+     *   status?: string,
+     *   templateID?: string,
+     * }|RunListParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunListResponse>
+     *
+     * @throws APIException
+     */
+    public function list(
+        array|RunListParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = RunListParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: 'journeys/runs',
+            query: Util::array_transform_keys(
+                $parsed,
+                [
+                    'endDate' => 'end_date',
+                    'startDate' => 'start_date',
+                    'templateID' => 'template_id',
+                ],
+            ),
+            options: $options,
+            convert: JourneyRunListResponse::class,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * List the per-node state of one Journey run, in full — this endpoint is not paginated. Each step's `node_id` is the id of the node in the published Journey, so a step maps directly onto the Journey graph. `message_id` is present on send steps that produced a message; follow it to `GET /messages/{message_id}` for delivery status.
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<JourneyRunStepsResponse>
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): BaseResponse {
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['journeys/runs/%1$s/steps', $runID],
+            options: $requestOptions,
+            convert: JourneyRunStepsResponse::class,
+        );
+    }
+}

--- a/src/Services/Journeys/RunsService.php
+++ b/src/Services/Journeys/RunsService.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Services\Journeys;
+
+use Courier\Client;
+use Courier\Core\Exceptions\APIException;
+use Courier\Core\Util;
+use Courier\Journeys\JourneyRunListResponse;
+use Courier\Journeys\JourneyRunResponse;
+use Courier\Journeys\JourneyRunStepsResponse;
+use Courier\RequestOptions;
+use Courier\ServiceContracts\Journeys\RunsContract;
+
+/**
+ * Build, version, publish, invoke, and cancel multi-step notification workflows, along with the templates scoped to them.
+ *
+ * @phpstan-import-type RequestOpts from \Courier\RequestOptions
+ */
+final class RunsService implements RunsContract
+{
+    /**
+     * @api
+     */
+    public RunsRawService $raw;
+
+    /**
+     * @internal
+     */
+    public function __construct(private Client $client)
+    {
+        $this->raw = new RunsRawService($client);
+    }
+
+    /**
+     * @api
+     *
+     * Fetch one Journey run by id. Returns `404` for an unknown run, a run belonging to another workspace, a run past the 95-day retention window, or an Automation run id — the same body in every case, so the response never reveals whether a run exists elsewhere.
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function retrieve(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): JourneyRunResponse {
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->retrieve($runID, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * List runs of the workspace's Journeys, newest first, filtered by status, Journey, or date range and paged by cursor. Runs of v2 Automations are listed by `GET /automations/runs` instead — the two surfaces never return each other's runs. Runs are retained for 95 days.
+     *
+     * @param string $cursor A cursor token for pagination. Use the `next_cursor` from the previous response to fetch the next page of results. Treat it as opaque.
+     * @param string $endDate an inclusive upper bound on `created_at`, in the same format as `start_date`
+     * @param string $limit The number of runs to return per page, between `1` and `50`. Defaults to `20`. Values outside the range are clamped, and a non-numeric value falls back to `20`.
+     * @param string $startDate An inclusive lower bound on `created_at`, as an ISO 8601 date or timestamp (e.g. `2026-08-18` or `2026-08-18T20:06:36.259Z`). Any other format returns `400`.
+     * @param string $status A comma-separated list of run statuses to filter on, e.g. `PROCESSED,ERROR`.
+     * @param string $templateID a comma-separated list of Journey ids to filter on
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function list(
+        ?string $cursor = null,
+        ?string $endDate = null,
+        ?string $limit = null,
+        ?string $startDate = null,
+        ?string $status = null,
+        ?string $templateID = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): JourneyRunListResponse {
+        $params = Util::removeNulls(
+            [
+                'cursor' => $cursor,
+                'endDate' => $endDate,
+                'limit' => $limit,
+                'startDate' => $startDate,
+                'status' => $status,
+                'templateID' => $templateID,
+            ],
+        );
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->list(params: $params, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * List the per-node state of one Journey run, in full — this endpoint is not paginated. Each step's `node_id` is the id of the node in the published Journey, so a step maps directly onto the Journey graph. `message_id` is present on send steps that produced a message; follow it to `GET /messages/{message_id}` for delivery status.
+     *
+     * @param string $runID a unique identifier representing the Journey run
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function listSteps(
+        string $runID,
+        RequestOptions|array|null $requestOptions = null
+    ): JourneyRunStepsResponse {
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->listSteps($runID, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+}

--- a/src/Services/JourneysService.php
+++ b/src/Services/JourneysService.php
@@ -17,6 +17,7 @@ use Courier\Journeys\JourneyState;
 use Courier\Journeys\JourneyVersionsListResponse;
 use Courier\RequestOptions;
 use Courier\ServiceContracts\JourneysContract;
+use Courier\Services\Journeys\RunsService;
 use Courier\Services\Journeys\TemplatesService;
 
 /**
@@ -37,12 +38,18 @@ final class JourneysService implements JourneysContract
     public TemplatesService $templates;
 
     /**
+     * @api
+     */
+    public RunsService $runs;
+
+    /**
      * @internal
      */
     public function __construct(private Client $client)
     {
         $this->raw = new JourneysRawService($client);
         $this->templates = new TemplatesService($client);
+        $this->runs = new RunsService($client);
     }
 
     /**

--- a/tests/Services/Automations/RunsTest.php
+++ b/tests/Services/Automations/RunsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Services\Automations;
+
+use Courier\Automations\AutomationRunListResponse;
+use Courier\Automations\AutomationRunStepsResponse;
+use Courier\Client;
+use Courier\Core\Util;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\UnsupportedMockTests;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class RunsTest extends TestCase
+{
+    protected Client $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $testUrl = Util::getenv('TEST_API_BASE_URL') ?: 'http://127.0.0.1:4010';
+        $client = new Client(apiKey: 'My API Key', baseUrl: $testUrl);
+
+        $this->client = $client;
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->automations->runs->list();
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(AutomationRunListResponse::class, $result);
+    }
+
+    #[Test]
+    public function testListSteps(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->automations->runs->listSteps('x');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(AutomationRunStepsResponse::class, $result);
+    }
+}

--- a/tests/Services/Journeys/RunsTest.php
+++ b/tests/Services/Journeys/RunsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Services\Journeys;
+
+use Courier\Client;
+use Courier\Core\Util;
+use Courier\Journeys\JourneyRunListResponse;
+use Courier\Journeys\JourneyRunResponse;
+use Courier\Journeys\JourneyRunStepsResponse;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\UnsupportedMockTests;
+
+/**
+ * @internal
+ */
+#[CoversNothing]
+final class RunsTest extends TestCase
+{
+    protected Client $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $testUrl = Util::getenv('TEST_API_BASE_URL') ?: 'http://127.0.0.1:4010';
+        $client = new Client(apiKey: 'My API Key', baseUrl: $testUrl);
+
+        $this->client = $client;
+    }
+
+    #[Test]
+    public function testRetrieve(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->journeys->runs->retrieve('x');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(JourneyRunResponse::class, $result);
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->journeys->runs->list();
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(JourneyRunListResponse::class, $result);
+    }
+
+    #[Test]
+    public function testListSteps(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->journeys->runs->listSteps('x');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(JourneyRunStepsResponse::class, $result);
+    }
+}


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**5 endpoint(s) added**

- `GET /automations/runs` — List Automation runs
- `GET /automations/runs/{id}/steps` — List steps for an Automation run
- `GET /journeys/runs` — List Journey runs
- `GET /journeys/runs/{run_id}` — Fetch a Journey run
- `GET /journeys/runs/{run_id}/steps` — List steps for a Journey run


## What changed in this SDK

34 files changed, 2816 insertions(+), 4 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                              |   2 +-
 src/Automations/AutomationRunListItem.php               | 161 +++++++++++++++++++++++++++++++
 src/Automations/AutomationRunListResponse.php           |  95 +++++++++++++++++++
 src/Automations/AutomationRunStep.php                   | 175 ++++++++++++++++++++++++++++++++++
 src/Automations/AutomationRunStepsResponse.php          |  74 +++++++++++++++
 src/Automations/Runs/RunListParams.php                  | 163 ++++++++++++++++++++++++++++++++
 src/Journeys/JourneyAudienceTriggerNode.php             | 162 ++++++++++++++++++++++++++++++++
 src/Journeys/JourneyAudienceTriggerNode/TriggerType.php |  10 ++
 src/Journeys/JourneyAudienceTriggerNode/Type.php        |  10 ++
 src/Journeys/JourneyNode.php                            |   8 +-
 src/Journeys/JourneyRun.php                             | 181 +++++++++++++++++++++++++++++++++++
 src/Journeys/JourneyRunListItem.php                     | 161 +++++++++++++++++++++++++++++++
 src/Journeys/JourneyRunListResponse.php                 | 117 +++++++++++++++++++++++
 src/Journeys/JourneyRunResponse.php                     |  76 +++++++++++++++
 src/Journeys/JourneyRunStep.php                         | 175 ++++++++++++++++++++++++++++++++++
 src/Journeys/JourneyRunStepsResponse.php                |  74 +++++++++++++++
 src/Journeys/JourneySegmentTriggerNode.php              |   2 +-
 src/Journeys/JourneySegmentTriggerNode/RequestType.php  |   2 +
 src/Journeys/JourneyWebhookTriggerNode.php              | 182 ++++++++++++++++++++++++++++++++++++
 src/Journeys/JourneyWebhookTriggerNode/TriggerType.php  |  10 ++
 src/Journeys/JourneyWebhookTriggerNode/Type.php         |  10 ++
 src/Journeys/Runs/RunListParams.php                     | 163 ++++++++++++++++++++++++++++++++
 src/ServiceContracts/Automations/RunsContract.php       |  52 +++++++++++
 src/ServiceContracts/Automations/RunsRawContract.php    |  48 ++++++++++
 src/ServiceContracts/Journeys/RunsContract.php          |  66 +++++++++++++
 src/ServiceContracts/Journeys/RunsRawContract.php       |  64 +++++++++++++
 src/Services/Automations/RunsRawService.php             |  99 ++++++++++++++++++++
 src/Services/Automations/RunsService.php                |  95 +++++++++++++++++++
 src/Services/AutomationsService.php                     |   7 ++
 src/Services/Journeys/RunsRawService.php                | 125 +++++++++++++++++++++++++
 src/Services/Journeys/RunsService.php                   | 116 +++++++++++++++++++++++
 src/Services/JourneysService.php                        |   7 ++
 tests/Services/Automations/RunsTest.php                 |  57 +++++++++++
 tests/Services/Journeys/RunsTest.php                    |  71 ++++++++++++++
 34 files changed, 2816 insertions(+), 4 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
