### PR TITLE
feat(api): document the template send metrics endpoint

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 154
+configured_endpoints: 155

--- a/src/Notifications/NotificationGetMetricsParams.php
+++ b/src/Notifications/NotificationGetMetricsParams.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Concerns\SdkParams;
+use Courier\Core\Contracts\BaseModel;
+use Courier\Notifications\NotificationGetMetricsParams\Granularity;
+
+/**
+ * Fetch the delivery funnel for one Notification Template as a time series — sent, delivered, opened, clicked, errors, and undeliverable — broken out per provider and channel inside each bucket. Sum the entries in a bucket for its totals; there is no bucket-level total.
+ *
+ * Choose the window absolutely with `start` and `end`, or relatively with `lookback` (an ISO 8601 duration). `start` and `end` take precedence when both are supplied, and a request carrying neither defaults to `lookback=P30D`. The window is snapped outwards onto the `granularity` grid so every bucket it overlaps is returned whole, and the snapped boundaries come back as `start` and `end` — align a chart on those rather than on what was requested. Every boundary is UTC; there is no timezone support.
+ *
+ * Every bucket in the window is returned, including the quiet ones, whose `data` array is empty, so a series is directly plottable with no gap filling client-side. An unknown template id returns `200` with an all-empty series rather than `404`, and messages sent without a Notification Template never appear here.
+ *
+ * Available in the US region only.
+ *
+ * @see Courier\Services\NotificationsService::getMetrics()
+ *
+ * @phpstan-type NotificationGetMetricsParamsShape = array{
+ *   end?: \DateTimeInterface|null,
+ *   granularity?: null|Granularity|value-of<Granularity>,
+ *   lookback?: string|null,
+ *   start?: \DateTimeInterface|null,
+ * }
+ */
+final class NotificationGetMetricsParams implements BaseModel
+{
+    /** @use SdkModel<NotificationGetMetricsParamsShape> */
+    use SdkModel;
+    use SdkParams;
+
+    /**
+     * The end of the window, as an ISO 8601 timestamp with an offset. Must be supplied together with `start`. An `end` in the future is accepted and not clamped — the trailing buckets come back empty.
+     */
+    #[Optional]
+    public ?\DateTimeInterface $end;
+
+    /**
+     * The size of each bucket in the series. Defaults to `DAY`. `WEEK` buckets start on Sunday. A fine granularity caps the window it can cover: `HOUR` spans at most 7 days and `DAY` at most 90 days, and a wider window returns `400` — request a coarser granularity instead. `WEEK` and `MONTH` are uncapped, subject to the 1000-bucket limit on a single response.
+     *
+     * @var value-of<Granularity>|null $granularity
+     */
+    #[Optional(enum: Granularity::class)]
+    public ?string $granularity;
+
+    /**
+     * The length of the window, counted back from now, as an ISO 8601 duration (`P30D`, `P12W`, `PT12H`). Defaults to `P30D`, and is ignored when `start` and `end` are supplied. A malformed or non-positive duration returns `400`.
+     */
+    #[Optional]
+    public ?string $lookback;
+
+    /**
+     * The inclusive start of the window, as an ISO 8601 timestamp with an offset (`2026-04-01T00:00:00Z`). Must be supplied together with `end` and be earlier than it; either one alone returns `400`.
+     */
+    #[Optional]
+    public ?\DateTimeInterface $start;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param Granularity|value-of<Granularity>|null $granularity
+     */
+    public static function with(
+        ?\DateTimeInterface $end = null,
+        Granularity|string|null $granularity = null,
+        ?string $lookback = null,
+        ?\DateTimeInterface $start = null,
+    ): self {
+        $self = new self;
+
+        null !== $end && $self['end'] = $end;
+        null !== $granularity && $self['granularity'] = $granularity;
+        null !== $lookback && $self['lookback'] = $lookback;
+        null !== $start && $self['start'] = $start;
+
+        return $self;
+    }
+
+    /**
+     * The end of the window, as an ISO 8601 timestamp with an offset. Must be supplied together with `start`. An `end` in the future is accepted and not clamped — the trailing buckets come back empty.
+     */
+    public function withEnd(\DateTimeInterface $end): self
+    {
+        $self = clone $this;
+        $self['end'] = $end;
+
+        return $self;
+    }
+
+    /**
+     * The size of each bucket in the series. Defaults to `DAY`. `WEEK` buckets start on Sunday. A fine granularity caps the window it can cover: `HOUR` spans at most 7 days and `DAY` at most 90 days, and a wider window returns `400` — request a coarser granularity instead. `WEEK` and `MONTH` are uncapped, subject to the 1000-bucket limit on a single response.
+     *
+     * @param Granularity|value-of<Granularity> $granularity
+     */
+    public function withGranularity(Granularity|string $granularity): self
+    {
+        $self = clone $this;
+        $self['granularity'] = $granularity;
+
+        return $self;
+    }
+
+    /**
+     * The length of the window, counted back from now, as an ISO 8601 duration (`P30D`, `P12W`, `PT12H`). Defaults to `P30D`, and is ignored when `start` and `end` are supplied. A malformed or non-positive duration returns `400`.
+     */
+    public function withLookback(string $lookback): self
+    {
+        $self = clone $this;
+        $self['lookback'] = $lookback;
+
+        return $self;
+    }
+
+    /**
+     * The inclusive start of the window, as an ISO 8601 timestamp with an offset (`2026-04-01T00:00:00Z`). Must be supplied together with `end` and be earlier than it; either one alone returns `400`.
+     */
+    public function withStart(\DateTimeInterface $start): self
+    {
+        $self = clone $this;
+        $self['start'] = $start;
+
+        return $self;
+    }
+}

--- a/src/Notifications/NotificationGetMetricsParams/Granularity.php
+++ b/src/Notifications/NotificationGetMetricsParams/Granularity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications\NotificationGetMetricsParams;
+
+/**
+ * The size of each bucket in the series. Defaults to `DAY`. `WEEK` buckets start on Sunday. A fine granularity caps the window it can cover: `HOUR` spans at most 7 days and `DAY` at most 90 days, and a wider window returns `400` — request a coarser granularity instead. `WEEK` and `MONTH` are uncapped, subject to the 1000-bucket limit on a single response.
+ */
+enum Granularity: string
+{
+    case HOUR = 'HOUR';
+
+    case DAY = 'DAY';
+
+    case WEEK = 'WEEK';
+
+    case MONTH = 'MONTH';
+}

--- a/src/Notifications/NotificationMetricsResponse.php
+++ b/src/Notifications/NotificationMetricsResponse.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\Notifications\NotificationMetricsResponse\Granularity;
+use Courier\Notifications\NotificationMetricsResponse\Series;
+
+/**
+ * @phpstan-import-type SeriesShape from \Courier\Notifications\NotificationMetricsResponse\Series
+ *
+ * @phpstan-type NotificationMetricsResponseShape = array{
+ *   end: \DateTimeInterface,
+ *   granularity: Granularity|value-of<Granularity>,
+ *   notificationID: string,
+ *   series: list<Series|SeriesShape>,
+ *   start: \DateTimeInterface,
+ * }
+ */
+final class NotificationMetricsResponse implements BaseModel
+{
+    /** @use SdkModel<NotificationMetricsResponseShape> */
+    use SdkModel;
+
+    /**
+     * End of the window actually queried, ceiled onto the granularity grid. Second-precision UTC.
+     */
+    #[Required]
+    public \DateTimeInterface $end;
+
+    /**
+     * Bucket size the series was built at.
+     *
+     * @var value-of<Granularity> $granularity
+     */
+    #[Required(enum: Granularity::class)]
+    public string $granularity;
+
+    /**
+     * The template the series describes, echoed from the request.
+     */
+    #[Required('notificationId')]
+    public string $notificationID;
+
+    /**
+     * One entry per bucket between `start` and `end`, oldest first, including buckets with no activity.
+     *
+     * @var list<Series> $series
+     */
+    #[Required(list: Series::class)]
+    public array $series;
+
+    /**
+     * Inclusive start of the window actually queried, floored onto the granularity grid. Second-precision UTC.
+     */
+    #[Required]
+    public \DateTimeInterface $start;
+
+    /**
+     * `new NotificationMetricsResponse()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * NotificationMetricsResponse::with(
+     *   end: ..., granularity: ..., notificationID: ..., series: ..., start: ...
+     * )
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new NotificationMetricsResponse)
+     *   ->withEnd(...)
+     *   ->withGranularity(...)
+     *   ->withNotificationID(...)
+     *   ->withSeries(...)
+     *   ->withStart(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param Granularity|value-of<Granularity> $granularity
+     * @param list<Series|SeriesShape> $series
+     */
+    public static function with(
+        \DateTimeInterface $end,
+        Granularity|string $granularity,
+        string $notificationID,
+        array $series,
+        \DateTimeInterface $start,
+    ): self {
+        $self = new self;
+
+        $self['end'] = $end;
+        $self['granularity'] = $granularity;
+        $self['notificationID'] = $notificationID;
+        $self['series'] = $series;
+        $self['start'] = $start;
+
+        return $self;
+    }
+
+    /**
+     * End of the window actually queried, ceiled onto the granularity grid. Second-precision UTC.
+     */
+    public function withEnd(\DateTimeInterface $end): self
+    {
+        $self = clone $this;
+        $self['end'] = $end;
+
+        return $self;
+    }
+
+    /**
+     * Bucket size the series was built at.
+     *
+     * @param Granularity|value-of<Granularity> $granularity
+     */
+    public function withGranularity(Granularity|string $granularity): self
+    {
+        $self = clone $this;
+        $self['granularity'] = $granularity;
+
+        return $self;
+    }
+
+    /**
+     * The template the series describes, echoed from the request.
+     */
+    public function withNotificationID(string $notificationID): self
+    {
+        $self = clone $this;
+        $self['notificationID'] = $notificationID;
+
+        return $self;
+    }
+
+    /**
+     * One entry per bucket between `start` and `end`, oldest first, including buckets with no activity.
+     *
+     * @param list<Series|SeriesShape> $series
+     */
+    public function withSeries(array $series): self
+    {
+        $self = clone $this;
+        $self['series'] = $series;
+
+        return $self;
+    }
+
+    /**
+     * Inclusive start of the window actually queried, floored onto the granularity grid. Second-precision UTC.
+     */
+    public function withStart(\DateTimeInterface $start): self
+    {
+        $self = clone $this;
+        $self['start'] = $start;
+
+        return $self;
+    }
+}

--- a/src/Notifications/NotificationMetricsResponse/Granularity.php
+++ b/src/Notifications/NotificationMetricsResponse/Granularity.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications\NotificationMetricsResponse;
+
+/**
+ * Bucket size the series was built at.
+ */
+enum Granularity: string
+{
+    case HOUR = 'HOUR';
+
+    case DAY = 'DAY';
+
+    case WEEK = 'WEEK';
+
+    case MONTH = 'MONTH';
+}

--- a/src/Notifications/NotificationMetricsResponse/Series.php
+++ b/src/Notifications/NotificationMetricsResponse/Series.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications\NotificationMetricsResponse;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\Notifications\NotificationMetricsResponse\Series\Data;
+
+/**
+ * @phpstan-import-type DataShape from \Courier\Notifications\NotificationMetricsResponse\Series\Data
+ *
+ * @phpstan-type SeriesShape = array{
+ *   data: list<Data|DataShape>, period: \DateTimeInterface
+ * }
+ */
+final class Series implements BaseModel
+{
+    /** @use SdkModel<SeriesShape> */
+    use SdkModel;
+
+    /**
+     * One entry per provider and channel that handled a message in this bucket. Empty when nothing was sent.
+     *
+     * @var list<Data> $data
+     */
+    #[Required(list: Data::class)]
+    public array $data;
+
+    /**
+     * Start of the bucket, second-precision UTC.
+     */
+    #[Required]
+    public \DateTimeInterface $period;
+
+    /**
+     * `new Series()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * Series::with(data: ..., period: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new Series)->withData(...)->withPeriod(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<Data|DataShape> $data
+     */
+    public static function with(array $data, \DateTimeInterface $period): self
+    {
+        $self = new self;
+
+        $self['data'] = $data;
+        $self['period'] = $period;
+
+        return $self;
+    }
+
+    /**
+     * One entry per provider and channel that handled a message in this bucket. Empty when nothing was sent.
+     *
+     * @param list<Data|DataShape> $data
+     */
+    public function withData(array $data): self
+    {
+        $self = clone $this;
+        $self['data'] = $data;
+
+        return $self;
+    }
+
+    /**
+     * Start of the bucket, second-precision UTC.
+     */
+    public function withPeriod(\DateTimeInterface $period): self
+    {
+        $self = clone $this;
+        $self['period'] = $period;
+
+        return $self;
+    }
+}

--- a/src/Notifications/NotificationMetricsResponse/Series/Data.php
+++ b/src/Notifications/NotificationMetricsResponse/Series/Data.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Notifications\NotificationMetricsResponse\Series;
+
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-type DataShape = array{
+ *   channel: string,
+ *   clicked: int,
+ *   delivered: int,
+ *   errors: int,
+ *   opened: int,
+ *   provider: string,
+ *   sent: int,
+ *   undeliverable: int,
+ * }
+ */
+final class Data implements BaseModel
+{
+    /** @use SdkModel<DataShape> */
+    use SdkModel;
+
+    /**
+     * Channel the provider delivered on, e.g. `email`.
+     */
+    #[Required]
+    public string $channel;
+
+    /**
+     * Messages with at least one tracked link click.
+     */
+    #[Required]
+    public int $clicked;
+
+    /**
+     * Messages the provider confirmed as delivered.
+     */
+    #[Required]
+    public int $delivered;
+
+    /**
+     * Messages the provider rejected or failed on, including ones a later provider then delivered.
+     */
+    #[Required]
+    public int $errors;
+
+    /**
+     * Messages opened at least once. Always `0` on channels with no open tracking.
+     */
+    #[Required]
+    public int $opened;
+
+    /**
+     * Provider that handled the messages, e.g. `sendgrid`.
+     */
+    #[Required]
+    public string $provider;
+
+    /**
+     * Messages handed to the provider.
+     */
+    #[Required]
+    public int $sent;
+
+    /**
+     * Messages Courier could not deliver on any provider for the channel.
+     */
+    #[Required]
+    public int $undeliverable;
+
+    /**
+     * `new Data()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * Data::with(
+     *   channel: ...,
+     *   clicked: ...,
+     *   delivered: ...,
+     *   errors: ...,
+     *   opened: ...,
+     *   provider: ...,
+     *   sent: ...,
+     *   undeliverable: ...,
+     * )
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new Data)
+     *   ->withChannel(...)
+     *   ->withClicked(...)
+     *   ->withDelivered(...)
+     *   ->withErrors(...)
+     *   ->withOpened(...)
+     *   ->withProvider(...)
+     *   ->withSent(...)
+     *   ->withUndeliverable(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        string $channel,
+        int $clicked,
+        int $delivered,
+        int $errors,
+        int $opened,
+        string $provider,
+        int $sent,
+        int $undeliverable,
+    ): self {
+        $self = new self;
+
+        $self['channel'] = $channel;
+        $self['clicked'] = $clicked;
+        $self['delivered'] = $delivered;
+        $self['errors'] = $errors;
+        $self['opened'] = $opened;
+        $self['provider'] = $provider;
+        $self['sent'] = $sent;
+        $self['undeliverable'] = $undeliverable;
+
+        return $self;
+    }
+
+    /**
+     * Channel the provider delivered on, e.g. `email`.
+     */
+    public function withChannel(string $channel): self
+    {
+        $self = clone $this;
+        $self['channel'] = $channel;
+
+        return $self;
+    }
+
+    /**
+     * Messages with at least one tracked link click.
+     */
+    public function withClicked(int $clicked): self
+    {
+        $self = clone $this;
+        $self['clicked'] = $clicked;
+
+        return $self;
+    }
+
+    /**
+     * Messages the provider confirmed as delivered.
+     */
+    public function withDelivered(int $delivered): self
+    {
+        $self = clone $this;
+        $self['delivered'] = $delivered;
+
+        return $self;
+    }
+
+    /**
+     * Messages the provider rejected or failed on, including ones a later provider then delivered.
+     */
+    public function withErrors(int $errors): self
+    {
+        $self = clone $this;
+        $self['errors'] = $errors;
+
+        return $self;
+    }
+
+    /**
+     * Messages opened at least once. Always `0` on channels with no open tracking.
+     */
+    public function withOpened(int $opened): self
+    {
+        $self = clone $this;
+        $self['opened'] = $opened;
+
+        return $self;
+    }
+
+    /**
+     * Provider that handled the messages, e.g. `sendgrid`.
+     */
+    public function withProvider(string $provider): self
+    {
+        $self = clone $this;
+        $self['provider'] = $provider;
+
+        return $self;
+    }
+
+    /**
+     * Messages handed to the provider.
+     */
+    public function withSent(int $sent): self
+    {
+        $self = clone $this;
+        $self['sent'] = $sent;
+
+        return $self;
+    }
+
+    /**
+     * Messages Courier could not deliver on any provider for the channel.
+     */
+    public function withUndeliverable(int $undeliverable): self
+    {
+        $self = clone $this;
+        $self['undeliverable'] = $undeliverable;
+
+        return $self;
+    }
+}

--- a/src/ServiceContracts/NotificationsContract.php
+++ b/src/ServiceContracts/NotificationsContract.php
@@ -9,7 +9,9 @@ use Courier\Notifications\NotificationContentGetResponse;
 use Courier\Notifications\NotificationContentMutationResponse;
 use Courier\Notifications\NotificationCreateParams\State;
 use Courier\Notifications\NotificationGetContent;
+use Courier\Notifications\NotificationGetMetricsParams\Granularity;
 use Courier\Notifications\NotificationListResponse;
+use Courier\Notifications\NotificationMetricsResponse;
 use Courier\Notifications\NotificationPutContentParams\Content;
 use Courier\Notifications\NotificationPutLocaleParams\Element;
 use Courier\Notifications\NotificationTemplateResponse;
@@ -89,6 +91,27 @@ interface NotificationsContract
         string $id,
         RequestOptions|array|null $requestOptions = null
     ): mixed;
+
+    /**
+     * @api
+     *
+     * @param string $id The Notification Template to report on — its ID (`nt_` prefix) or an alias. Must not contain commas or whitespace.
+     * @param \DateTimeInterface $end The end of the window, as an ISO 8601 timestamp with an offset. Must be supplied together with `start`. An `end` in the future is accepted and not clamped — the trailing buckets come back empty.
+     * @param Granularity|value-of<Granularity> $granularity The size of each bucket in the series. Defaults to `DAY`. `WEEK` buckets start on Sunday. A fine granularity caps the window it can cover: `HOUR` spans at most 7 days and `DAY` at most 90 days, and a wider window returns `400` — request a coarser granularity instead. `WEEK` and `MONTH` are uncapped, subject to the 1000-bucket limit on a single response.
+     * @param string $lookback The length of the window, counted back from now, as an ISO 8601 duration (`P30D`, `P12W`, `PT12H`). Defaults to `P30D`, and is ignored when `start` and `end` are supplied. A malformed or non-positive duration returns `400`.
+     * @param \DateTimeInterface $start The inclusive start of the window, as an ISO 8601 timestamp with an offset (`2026-04-01T00:00:00Z`). Must be supplied together with `end` and be earlier than it; either one alone returns `400`.
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function getMetrics(
+        string $id,
+        ?\DateTimeInterface $end = null,
+        Granularity|string $granularity = 'DAY',
+        string $lookback = 'P30D',
+        ?\DateTimeInterface $start = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): NotificationMetricsResponse;
 
     /**
      * @api

--- a/src/ServiceContracts/NotificationsRawContract.php
+++ b/src/ServiceContracts/NotificationsRawContract.php
@@ -10,9 +10,11 @@ use Courier\Notifications\NotificationContentGetResponse;
 use Courier\Notifications\NotificationContentMutationResponse;
 use Courier\Notifications\NotificationCreateParams;
 use Courier\Notifications\NotificationGetContent;
+use Courier\Notifications\NotificationGetMetricsParams;
 use Courier\Notifications\NotificationListParams;
 use Courier\Notifications\NotificationListResponse;
 use Courier\Notifications\NotificationListVersionsParams;
+use Courier\Notifications\NotificationMetricsResponse;
 use Courier\Notifications\NotificationPublishParams;
 use Courier\Notifications\NotificationPutContentParams;
 use Courier\Notifications\NotificationPutElementParams;
@@ -89,6 +91,23 @@ interface NotificationsRawContract
     public function archive(
         string $id,
         RequestOptions|array|null $requestOptions = null
+    ): BaseResponse;
+
+    /**
+     * @api
+     *
+     * @param string $id The Notification Template to report on — its ID (`nt_` prefix) or an alias. Must not contain commas or whitespace.
+     * @param array<string,mixed>|NotificationGetMetricsParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<NotificationMetricsResponse>
+     *
+     * @throws APIException
+     */
+    public function getMetrics(
+        string $id,
+        array|NotificationGetMetricsParams $params,
+        RequestOptions|array|null $requestOptions = null,
     ): BaseResponse;
 
     /**

--- a/src/Services/NotificationsRawService.php
+++ b/src/Services/NotificationsRawService.php
@@ -14,9 +14,12 @@ use Courier\Notifications\NotificationCreateParams;
 use Courier\Notifications\NotificationCreateParams\State;
 use Courier\Notifications\NotificationGetContent;
 use Courier\Notifications\NotificationGetContentResponse;
+use Courier\Notifications\NotificationGetMetricsParams;
+use Courier\Notifications\NotificationGetMetricsParams\Granularity;
 use Courier\Notifications\NotificationListParams;
 use Courier\Notifications\NotificationListResponse;
 use Courier\Notifications\NotificationListVersionsParams;
+use Courier\Notifications\NotificationMetricsResponse;
 use Courier\Notifications\NotificationPublishParams;
 use Courier\Notifications\NotificationPutContentParams;
 use Courier\Notifications\NotificationPutContentParams\Content;
@@ -184,6 +187,50 @@ final class NotificationsRawService implements NotificationsRawContract
             path: ['notifications/%1$s', $id],
             options: $requestOptions,
             convert: null,
+        );
+    }
+
+    /**
+     * @api
+     *
+     * Fetch the delivery funnel for one Notification Template as a time series — sent, delivered, opened, clicked, errors, and undeliverable — broken out per provider and channel inside each bucket. Sum the entries in a bucket for its totals; there is no bucket-level total.
+     *
+     * Choose the window absolutely with `start` and `end`, or relatively with `lookback` (an ISO 8601 duration). `start` and `end` take precedence when both are supplied, and a request carrying neither defaults to `lookback=P30D`. The window is snapped outwards onto the `granularity` grid so every bucket it overlaps is returned whole, and the snapped boundaries come back as `start` and `end` — align a chart on those rather than on what was requested. Every boundary is UTC; there is no timezone support.
+     *
+     * Every bucket in the window is returned, including the quiet ones, whose `data` array is empty, so a series is directly plottable with no gap filling client-side. An unknown template id returns `200` with an all-empty series rather than `404`, and messages sent without a Notification Template never appear here.
+     *
+     * Available in the US region only.
+     *
+     * @param string $id The Notification Template to report on — its ID (`nt_` prefix) or an alias. Must not contain commas or whitespace.
+     * @param array{
+     *   end?: \DateTimeInterface,
+     *   granularity?: Granularity|value-of<Granularity>,
+     *   lookback?: string,
+     *   start?: \DateTimeInterface,
+     * }|NotificationGetMetricsParams $params
+     * @param RequestOpts|null $requestOptions
+     *
+     * @return BaseResponse<NotificationMetricsResponse>
+     *
+     * @throws APIException
+     */
+    public function getMetrics(
+        string $id,
+        array|NotificationGetMetricsParams $params,
+        RequestOptions|array|null $requestOptions = null,
+    ): BaseResponse {
+        [$parsed, $options] = NotificationGetMetricsParams::parseRequest(
+            $params,
+            $requestOptions,
+        );
+
+        // @phpstan-ignore-next-line return.type
+        return $this->client->request(
+            method: 'get',
+            path: ['notifications/%1$s/metrics', $id],
+            query: $parsed,
+            options: $options,
+            convert: NotificationMetricsResponse::class,
         );
     }
 

--- a/src/Services/NotificationsService.php
+++ b/src/Services/NotificationsService.php
@@ -11,7 +11,9 @@ use Courier\Notifications\NotificationContentGetResponse;
 use Courier\Notifications\NotificationContentMutationResponse;
 use Courier\Notifications\NotificationCreateParams\State;
 use Courier\Notifications\NotificationGetContent;
+use Courier\Notifications\NotificationGetMetricsParams\Granularity;
 use Courier\Notifications\NotificationListResponse;
+use Courier\Notifications\NotificationMetricsResponse;
 use Courier\Notifications\NotificationPutContentParams\Content;
 use Courier\Notifications\NotificationPutLocaleParams\Element;
 use Courier\Notifications\NotificationTemplateResponse;
@@ -154,6 +156,49 @@ final class NotificationsService implements NotificationsContract
     ): mixed {
         // @phpstan-ignore-next-line argument.type
         $response = $this->raw->archive($id, requestOptions: $requestOptions);
+
+        return $response->parse();
+    }
+
+    /**
+     * @api
+     *
+     * Fetch the delivery funnel for one Notification Template as a time series — sent, delivered, opened, clicked, errors, and undeliverable — broken out per provider and channel inside each bucket. Sum the entries in a bucket for its totals; there is no bucket-level total.
+     *
+     * Choose the window absolutely with `start` and `end`, or relatively with `lookback` (an ISO 8601 duration). `start` and `end` take precedence when both are supplied, and a request carrying neither defaults to `lookback=P30D`. The window is snapped outwards onto the `granularity` grid so every bucket it overlaps is returned whole, and the snapped boundaries come back as `start` and `end` — align a chart on those rather than on what was requested. Every boundary is UTC; there is no timezone support.
+     *
+     * Every bucket in the window is returned, including the quiet ones, whose `data` array is empty, so a series is directly plottable with no gap filling client-side. An unknown template id returns `200` with an all-empty series rather than `404`, and messages sent without a Notification Template never appear here.
+     *
+     * Available in the US region only.
+     *
+     * @param string $id The Notification Template to report on — its ID (`nt_` prefix) or an alias. Must not contain commas or whitespace.
+     * @param \DateTimeInterface $end The end of the window, as an ISO 8601 timestamp with an offset. Must be supplied together with `start`. An `end` in the future is accepted and not clamped — the trailing buckets come back empty.
+     * @param Granularity|value-of<Granularity> $granularity The size of each bucket in the series. Defaults to `DAY`. `WEEK` buckets start on Sunday. A fine granularity caps the window it can cover: `HOUR` spans at most 7 days and `DAY` at most 90 days, and a wider window returns `400` — request a coarser granularity instead. `WEEK` and `MONTH` are uncapped, subject to the 1000-bucket limit on a single response.
+     * @param string $lookback The length of the window, counted back from now, as an ISO 8601 duration (`P30D`, `P12W`, `PT12H`). Defaults to `P30D`, and is ignored when `start` and `end` are supplied. A malformed or non-positive duration returns `400`.
+     * @param \DateTimeInterface $start The inclusive start of the window, as an ISO 8601 timestamp with an offset (`2026-04-01T00:00:00Z`). Must be supplied together with `end` and be earlier than it; either one alone returns `400`.
+     * @param RequestOpts|null $requestOptions
+     *
+     * @throws APIException
+     */
+    public function getMetrics(
+        string $id,
+        ?\DateTimeInterface $end = null,
+        Granularity|string $granularity = 'DAY',
+        string $lookback = 'P30D',
+        ?\DateTimeInterface $start = null,
+        RequestOptions|array|null $requestOptions = null,
+    ): NotificationMetricsResponse {
+        $params = Util::removeNulls(
+            [
+                'end' => $end,
+                'granularity' => $granularity,
+                'lookback' => $lookback,
+                'start' => $start,
+            ],
+        );
+
+        // @phpstan-ignore-next-line argument.type
+        $response = $this->raw->getMetrics($id, params: $params, requestOptions: $requestOptions);
 
         return $response->parse();
     }

--- a/tests/Services/NotificationsTest.php
+++ b/tests/Services/NotificationsTest.php
@@ -6,6 +6,7 @@ use Courier\Client;
 use Courier\Core\Util;
 use Courier\Notifications\NotificationContentMutationResponse;
 use Courier\Notifications\NotificationListResponse;
+use Courier\Notifications\NotificationMetricsResponse;
 use Courier\Notifications\NotificationTemplateResponse;
 use Courier\Notifications\NotificationTemplateState;
 use Courier\Notifications\NotificationTemplateVersionListResponse;
@@ -119,6 +120,19 @@ final class NotificationsTest extends TestCase
 
         // @phpstan-ignore-next-line method.alreadyNarrowedType
         $this->assertNull($result);
+    }
+
+    #[Test]
+    public function testGetMetrics(): void
+    {
+        if (UnsupportedMockTests::$skip) {
+            $this->markTestSkipped('Mock server tests are disabled');
+        }
+
+        $result = $this->client->notifications->getMetrics('x');
+
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertInstanceOf(NotificationMetricsResponse::class, $result);
     }
 
     #[Test]


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**1 endpoint(s) added**

- `GET /notifications/{id}/metrics` — Get Notification Template Metrics


## What changed in this SDK

12 files changed, 821 insertions(+), 1 deletion(-)

<details><summary>Files</summary>

```
 .stats.yml                                                     |   2 +-
 src/Notifications/NotificationGetMetricsParams.php             | 136 +++++++++++++++++
 src/Notifications/NotificationGetMetricsParams/Granularity.php |  19 +++
 src/Notifications/NotificationMetricsResponse.php              | 173 ++++++++++++++++++++++
 src/Notifications/NotificationMetricsResponse/Granularity.php  |  19 +++
 src/Notifications/NotificationMetricsResponse/Series.php       |  97 ++++++++++++
 src/Notifications/NotificationMetricsResponse/Series/Data.php  | 228 +++++++++++++++++++++++++++++
 src/ServiceContracts/NotificationsContract.php                 |  23 +++
 src/ServiceContracts/NotificationsRawContract.php              |  19 +++
 src/Services/NotificationsRawService.php                       |  47 ++++++
 src/Services/NotificationsService.php                          |  45 ++++++
 tests/Services/NotificationsTest.php                           |  14 ++
 12 files changed, 821 insertions(+), 1 deletion(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
