### PR TITLE
feat(api): document Slack and MS Teams on journey send nodes, and fix over-strict MsTeams tenant requirements [C-20302]

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '7.0.0',
+            'X-Stainless-Package-Version' => '7.1.0',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/Journeys/JourneySendNode/Message.php
+++ b/src/Journeys/JourneySendNode/Message.php
@@ -45,6 +45,9 @@ final class Message implements BaseModel
     #[Optional]
     public ?string $template;
 
+    /**
+     * Recipient override for this send. Provide exactly one of `email_override`, `phone_number_override`, `user_id_override`, `slack`, or `ms_teams` — not a combination.
+     */
     #[Optional]
     public ?To $to;
 
@@ -125,6 +128,8 @@ final class Message implements BaseModel
     }
 
     /**
+     * Recipient override for this send. Provide exactly one of `email_override`, `phone_number_override`, `user_id_override`, `slack`, or `ms_teams` — not a combination.
+     *
      * @param To|ToShape $to
      */
     public function withTo(To|array $to): self

--- a/src/Journeys/JourneySendNode/Message/To.php
+++ b/src/Journeys/JourneySendNode/Message/To.php
@@ -7,11 +7,23 @@ namespace Courier\Journeys\JourneySendNode\Message;
 use Courier\Core\Attributes\Optional;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
+use Courier\Journeys\JourneySendNodeToMsTeams;
+use Courier\Journeys\JourneySendNodeToSlackChannel;
+use Courier\Journeys\JourneySendNodeToSlackEmail;
+use Courier\Journeys\JourneySendNodeToSlackUserID;
 
 /**
+ * Recipient override for this send. Provide exactly one of `email_override`, `phone_number_override`, `user_id_override`, `slack`, or `ms_teams` — not a combination.
+ *
+ * @phpstan-import-type JourneySendNodeToSlackVariants from \Courier\Journeys\JourneySendNodeToSlack
+ * @phpstan-import-type JourneySendNodeToMsTeamsShape from \Courier\Journeys\JourneySendNodeToMsTeams
+ * @phpstan-import-type JourneySendNodeToSlackShape from \Courier\Journeys\JourneySendNodeToSlack
+ *
  * @phpstan-type ToShape = array{
  *   emailOverride?: string|null,
+ *   msTeams?: null|JourneySendNodeToMsTeams|JourneySendNodeToMsTeamsShape,
  *   phoneNumberOverride?: string|null,
+ *   slack?: JourneySendNodeToSlackShape|null,
  *   userIDOverride?: string|null,
  * }
  */
@@ -23,8 +35,22 @@ final class To implements BaseModel
     #[Optional('email_override')]
     public ?string $emailOverride;
 
+    /**
+     * Send to a Microsoft Teams address directly, bypassing the recipient's stored profile. Requires exactly one target: `channel_id`, `channel_name` (with `team_id`), `user_id`, or `email`. `channel_name`, `user_id`, and `email` also need at least one of `service_url` or `tenant_id` — if you provide both, they must agree. `channel_id` doesn't require tenant context to publish, but provide `service_url` or `tenant_id` anyway: sends without either have failed at delivery in testing. `conversation_id` and `reply_to_activity_id`, available on the send API's `MsTeams` profile, aren't supported here yet.
+     */
+    #[Optional('ms_teams')]
+    public ?JourneySendNodeToMsTeams $msTeams;
+
     #[Optional('phone_number_override')]
     public ?string $phoneNumberOverride;
+
+    /**
+     * Send to a Slack address directly, bypassing the recipient's stored profile. Requires exactly one of `channel`, `user_id`, or `email`.
+     *
+     * @var JourneySendNodeToSlackVariants|null $slack
+     */
+    #[Optional]
+    public JourneySendNodeToSlackChannel|JourneySendNodeToSlackUserID|JourneySendNodeToSlackEmail|null $slack;
 
     #[Optional('user_id_override')]
     public ?string $userIDOverride;
@@ -38,16 +64,23 @@ final class To implements BaseModel
      * Construct an instance from the required parameters.
      *
      * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param JourneySendNodeToMsTeams|JourneySendNodeToMsTeamsShape|null $msTeams
+     * @param JourneySendNodeToSlackShape|null $slack
      */
     public static function with(
         ?string $emailOverride = null,
+        JourneySendNodeToMsTeams|array|null $msTeams = null,
         ?string $phoneNumberOverride = null,
+        JourneySendNodeToSlackChannel|array|JourneySendNodeToSlackUserID|JourneySendNodeToSlackEmail|null $slack = null,
         ?string $userIDOverride = null,
     ): self {
         $self = new self;
 
         null !== $emailOverride && $self['emailOverride'] = $emailOverride;
+        null !== $msTeams && $self['msTeams'] = $msTeams;
         null !== $phoneNumberOverride && $self['phoneNumberOverride'] = $phoneNumberOverride;
+        null !== $slack && $self['slack'] = $slack;
         null !== $userIDOverride && $self['userIDOverride'] = $userIDOverride;
 
         return $self;
@@ -61,10 +94,37 @@ final class To implements BaseModel
         return $self;
     }
 
+    /**
+     * Send to a Microsoft Teams address directly, bypassing the recipient's stored profile. Requires exactly one target: `channel_id`, `channel_name` (with `team_id`), `user_id`, or `email`. `channel_name`, `user_id`, and `email` also need at least one of `service_url` or `tenant_id` — if you provide both, they must agree. `channel_id` doesn't require tenant context to publish, but provide `service_url` or `tenant_id` anyway: sends without either have failed at delivery in testing. `conversation_id` and `reply_to_activity_id`, available on the send API's `MsTeams` profile, aren't supported here yet.
+     *
+     * @param JourneySendNodeToMsTeams|JourneySendNodeToMsTeamsShape $msTeams
+     */
+    public function withMsTeams(JourneySendNodeToMsTeams|array $msTeams): self
+    {
+        $self = clone $this;
+        $self['msTeams'] = $msTeams;
+
+        return $self;
+    }
+
     public function withPhoneNumberOverride(string $phoneNumberOverride): self
     {
         $self = clone $this;
         $self['phoneNumberOverride'] = $phoneNumberOverride;
+
+        return $self;
+    }
+
+    /**
+     * Send to a Slack address directly, bypassing the recipient's stored profile. Requires exactly one of `channel`, `user_id`, or `email`.
+     *
+     * @param JourneySendNodeToSlackShape $slack
+     */
+    public function withSlack(
+        JourneySendNodeToSlackChannel|array|JourneySendNodeToSlackUserID|JourneySendNodeToSlackEmail $slack,
+    ): self {
+        $self = clone $this;
+        $self['slack'] = $slack;
 
         return $self;
     }

--- a/src/Journeys/JourneySendNodeToMsTeams.php
+++ b/src/Journeys/JourneySendNodeToMsTeams.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * Send to a Microsoft Teams address directly, bypassing the recipient's stored profile. Requires exactly one target: `channel_id`, `channel_name` (with `team_id`), `user_id`, or `email`. `channel_name`, `user_id`, and `email` also need at least one of `service_url` or `tenant_id` — if you provide both, they must agree. `channel_id` doesn't require tenant context to publish, but provide `service_url` or `tenant_id` anyway: sends without either have failed at delivery in testing. `conversation_id` and `reply_to_activity_id`, available on the send API's `MsTeams` profile, aren't supported here yet.
+ *
+ * @phpstan-type JourneySendNodeToMsTeamsShape = array{
+ *   channelID?: string|null,
+ *   channelName?: string|null,
+ *   email?: string|null,
+ *   serviceURL?: string|null,
+ *   teamID?: string|null,
+ *   tenantID?: string|null,
+ *   userID?: string|null,
+ * }
+ */
+final class JourneySendNodeToMsTeams implements BaseModel
+{
+    /** @use SdkModel<JourneySendNodeToMsTeamsShape> */
+    use SdkModel;
+
+    /**
+     * Bot Framework channel ID to send to.
+     */
+    #[Optional('channel_id')]
+    public ?string $channelID;
+
+    /**
+     * Teams channel name to send to. Requires `team_id`.
+     */
+    #[Optional('channel_name')]
+    public ?string $channelName;
+
+    /**
+     * Email address of the Teams user to send to.
+     */
+    #[Optional]
+    public ?string $email;
+
+    /**
+     * The regional Bot Framework host for this conversation, e.g. `https://smba.trafficmanager.net/amer`. A path segment naming the Microsoft tenant may follow it and is used to derive `tenant_id` when it is not supplied directly.
+     */
+    #[Optional('service_url')]
+    public ?string $serviceURL;
+
+    /**
+     * Microsoft Teams team ID. Required alongside `channel_name`.
+     */
+    #[Optional('team_id')]
+    public ?string $teamID;
+
+    /**
+     * The Microsoft (Azure AD) tenant this send targets or authenticates against. Unrelated to `message.context.tenant_id`, which is the Courier customer's own multi-tenant context.
+     */
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
+
+    /**
+     * Microsoft Teams user ID to send to.
+     */
+    #[Optional('user_id')]
+    public ?string $userID;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        ?string $channelID = null,
+        ?string $channelName = null,
+        ?string $email = null,
+        ?string $serviceURL = null,
+        ?string $teamID = null,
+        ?string $tenantID = null,
+        ?string $userID = null,
+    ): self {
+        $self = new self;
+
+        null !== $channelID && $self['channelID'] = $channelID;
+        null !== $channelName && $self['channelName'] = $channelName;
+        null !== $email && $self['email'] = $email;
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $teamID && $self['teamID'] = $teamID;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
+        null !== $userID && $self['userID'] = $userID;
+
+        return $self;
+    }
+
+    /**
+     * Bot Framework channel ID to send to.
+     */
+    public function withChannelID(string $channelID): self
+    {
+        $self = clone $this;
+        $self['channelID'] = $channelID;
+
+        return $self;
+    }
+
+    /**
+     * Teams channel name to send to. Requires `team_id`.
+     */
+    public function withChannelName(string $channelName): self
+    {
+        $self = clone $this;
+        $self['channelName'] = $channelName;
+
+        return $self;
+    }
+
+    /**
+     * Email address of the Teams user to send to.
+     */
+    public function withEmail(string $email): self
+    {
+        $self = clone $this;
+        $self['email'] = $email;
+
+        return $self;
+    }
+
+    /**
+     * The regional Bot Framework host for this conversation, e.g. `https://smba.trafficmanager.net/amer`. A path segment naming the Microsoft tenant may follow it and is used to derive `tenant_id` when it is not supplied directly.
+     */
+    public function withServiceURL(string $serviceURL): self
+    {
+        $self = clone $this;
+        $self['serviceURL'] = $serviceURL;
+
+        return $self;
+    }
+
+    /**
+     * Microsoft Teams team ID. Required alongside `channel_name`.
+     */
+    public function withTeamID(string $teamID): self
+    {
+        $self = clone $this;
+        $self['teamID'] = $teamID;
+
+        return $self;
+    }
+
+    /**
+     * The Microsoft (Azure AD) tenant this send targets or authenticates against. Unrelated to `message.context.tenant_id`, which is the Courier customer's own multi-tenant context.
+     */
+    public function withTenantID(string $tenantID): self
+    {
+        $self = clone $this;
+        $self['tenantID'] = $tenantID;
+
+        return $self;
+    }
+
+    /**
+     * Microsoft Teams user ID to send to.
+     */
+    public function withUserID(string $userID): self
+    {
+        $self = clone $this;
+        $self['userID'] = $userID;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneySendNodeToSlack.php
+++ b/src/Journeys/JourneySendNodeToSlack.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Concerns\SdkUnion;
+use Courier\Core\Conversion\Contracts\Converter;
+use Courier\Core\Conversion\Contracts\ConverterSource;
+
+/**
+ * Send to a Slack address directly, bypassing the recipient's stored profile. Requires exactly one of `channel`, `user_id`, or `email`.
+ *
+ * @phpstan-import-type JourneySendNodeToSlackChannelShape from \Courier\Journeys\JourneySendNodeToSlackChannel
+ * @phpstan-import-type JourneySendNodeToSlackUserIDShape from \Courier\Journeys\JourneySendNodeToSlackUserID
+ * @phpstan-import-type JourneySendNodeToSlackEmailShape from \Courier\Journeys\JourneySendNodeToSlackEmail
+ *
+ * @phpstan-type JourneySendNodeToSlackVariants = JourneySendNodeToSlackChannel|JourneySendNodeToSlackUserID|JourneySendNodeToSlackEmail
+ * @phpstan-type JourneySendNodeToSlackShape = JourneySendNodeToSlackVariants|JourneySendNodeToSlackChannelShape|JourneySendNodeToSlackUserIDShape|JourneySendNodeToSlackEmailShape
+ */
+final class JourneySendNodeToSlack implements ConverterSource
+{
+    use SdkUnion;
+
+    /**
+     * @return list<string|Converter|ConverterSource>|array<string,string|Converter|ConverterSource>
+     */
+    public static function variants(): array
+    {
+        return [
+            JourneySendNodeToSlackChannel::class,
+            JourneySendNodeToSlackUserID::class,
+            JourneySendNodeToSlackEmail::class,
+        ];
+    }
+}

--- a/src/Journeys/JourneySendNodeToSlackChannel.php
+++ b/src/Journeys/JourneySendNodeToSlackChannel.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-type JourneySendNodeToSlackChannelShape = array{
+ *   channel: string, accessToken?: string|null
+ * }
+ */
+final class JourneySendNodeToSlackChannel implements BaseModel
+{
+    /** @use SdkModel<JourneySendNodeToSlackChannelShape> */
+    use SdkModel;
+
+    /**
+     * Slack channel to send to, by name or ID.
+     */
+    #[Required]
+    public string $channel;
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    #[Optional('access_token')]
+    public ?string $accessToken;
+
+    /**
+     * `new JourneySendNodeToSlackChannel()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneySendNodeToSlackChannel::with(channel: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneySendNodeToSlackChannel)->withChannel(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        string $channel,
+        ?string $accessToken = null
+    ): self {
+        $self = new self;
+
+        $self['channel'] = $channel;
+
+        null !== $accessToken && $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+
+    /**
+     * Slack channel to send to, by name or ID.
+     */
+    public function withChannel(string $channel): self
+    {
+        $self = clone $this;
+        $self['channel'] = $channel;
+
+        return $self;
+    }
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    public function withAccessToken(string $accessToken): self
+    {
+        $self = clone $this;
+        $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneySendNodeToSlackEmail.php
+++ b/src/Journeys/JourneySendNodeToSlackEmail.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-type JourneySendNodeToSlackEmailShape = array{
+ *   email: string, accessToken?: string|null
+ * }
+ */
+final class JourneySendNodeToSlackEmail implements BaseModel
+{
+    /** @use SdkModel<JourneySendNodeToSlackEmailShape> */
+    use SdkModel;
+
+    /**
+     * Email address of the Slack user to send to, resolved via the workspace directory.
+     */
+    #[Required]
+    public string $email;
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    #[Optional('access_token')]
+    public ?string $accessToken;
+
+    /**
+     * `new JourneySendNodeToSlackEmail()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneySendNodeToSlackEmail::with(email: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneySendNodeToSlackEmail)->withEmail(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(string $email, ?string $accessToken = null): self
+    {
+        $self = new self;
+
+        $self['email'] = $email;
+
+        null !== $accessToken && $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+
+    /**
+     * Email address of the Slack user to send to, resolved via the workspace directory.
+     */
+    public function withEmail(string $email): self
+    {
+        $self = clone $this;
+        $self['email'] = $email;
+
+        return $self;
+    }
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    public function withAccessToken(string $accessToken): self
+    {
+        $self = clone $this;
+        $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+}

--- a/src/Journeys/JourneySendNodeToSlackUserID.php
+++ b/src/Journeys/JourneySendNodeToSlackUserID.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+
+/**
+ * @phpstan-type JourneySendNodeToSlackUserIDShape = array{
+ *   userID: string, accessToken?: string|null
+ * }
+ */
+final class JourneySendNodeToSlackUserID implements BaseModel
+{
+    /** @use SdkModel<JourneySendNodeToSlackUserIDShape> */
+    use SdkModel;
+
+    /**
+     * Slack user ID to send to.
+     */
+    #[Required('user_id')]
+    public string $userID;
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    #[Optional('access_token')]
+    public ?string $accessToken;
+
+    /**
+     * `new JourneySendNodeToSlackUserID()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * JourneySendNodeToSlackUserID::with(userID: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new JourneySendNodeToSlackUserID)->withUserID(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     */
+    public static function with(
+        string $userID,
+        ?string $accessToken = null
+    ): self {
+        $self = new self;
+
+        $self['userID'] = $userID;
+
+        null !== $accessToken && $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+
+    /**
+     * Slack user ID to send to.
+     */
+    public function withUserID(string $userID): self
+    {
+        $self = clone $this;
+        $self['userID'] = $userID;
+
+        return $self;
+    }
+
+    /**
+     * A runtime reference to a Slack access token, such as `{{data.slack_token}}`. Literal values are rejected — they'd be stored permanently with no way to rotate them. Omit to use the token on the recipient's stored Slack profile.
+     */
+    public function withAccessToken(string $accessToken): self
+    {
+        $self = clone $this;
+        $self['accessToken'] = $accessToken;
+
+        return $self;
+    }
+}

--- a/src/MsTeams.php
+++ b/src/MsTeams.php
@@ -9,6 +9,8 @@ use Courier\Core\Conversion\Contracts\Converter;
 use Courier\Core\Conversion\Contracts\ConverterSource;
 
 /**
+ * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+ *
  * @phpstan-import-type SendToMsTeamsUserIDShape from \Courier\SendToMsTeamsUserID
  * @phpstan-import-type SendToMsTeamsEmailShape from \Courier\SendToMsTeamsEmail
  * @phpstan-import-type SendToMsTeamsChannelIDShape from \Courier\SendToMsTeamsChannelID

--- a/src/MsTeamsBaseProperties.php
+++ b/src/MsTeamsBaseProperties.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Courier;
 
-use Courier\Core\Attributes\Required;
+use Courier\Core\Attributes\Optional;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 
 /**
+ * Tenant context shared by every MS Teams send variant. Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree — a `service_url` pointing at a different Microsoft tenant than `tenant_id` is rejected.
+ *
  * @phpstan-type MsTeamsBasePropertiesShape = array{
- *   serviceURL: string, tenantID: string
+ *   serviceURL?: string|null, tenantID?: string|null
  * }
  */
 final class MsTeamsBaseProperties implements BaseModel
@@ -18,26 +20,12 @@ final class MsTeamsBaseProperties implements BaseModel
     /** @use SdkModel<MsTeamsBasePropertiesShape> */
     use SdkModel;
 
-    #[Required('service_url')]
-    public string $serviceURL;
+    #[Optional('service_url')]
+    public ?string $serviceURL;
 
-    #[Required('tenant_id')]
-    public string $tenantID;
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
 
-    /**
-     * `new MsTeamsBaseProperties()` is missing required properties by the API.
-     *
-     * To enforce required parameters use
-     * ```
-     * MsTeamsBaseProperties::with(serviceURL: ..., tenantID: ...)
-     * ```
-     *
-     * Otherwise ensure the following setters are called
-     *
-     * ```
-     * (new MsTeamsBaseProperties)->withServiceURL(...)->withTenantID(...)
-     * ```
-     */
     public function __construct()
     {
         $this->initialize();
@@ -48,12 +36,14 @@ final class MsTeamsBaseProperties implements BaseModel
      *
      * You must use named parameters to construct any parameters with a default value.
      */
-    public static function with(string $serviceURL, string $tenantID): self
-    {
+    public static function with(
+        ?string $serviceURL = null,
+        ?string $tenantID = null
+    ): self {
         $self = new self;
 
-        $self['serviceURL'] = $serviceURL;
-        $self['tenantID'] = $tenantID;
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
 
         return $self;
     }

--- a/src/MsTeamsRecipient.php
+++ b/src/MsTeamsRecipient.php
@@ -21,7 +21,11 @@ final class MsTeamsRecipient implements BaseModel
     /** @use SdkModel<MsTeamsRecipientShape> */
     use SdkModel;
 
-    /** @var MsTeamsVariants $msTeams */
+    /**
+     * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+     *
+     * @var MsTeamsVariants $msTeams
+     */
     #[Required('ms_teams')]
     public SendToMsTeamsUserID|SendToMsTeamsEmail|SendToMsTeamsChannelID|SendToMsTeamsConversationID|SendToMsTeamsChannelName $msTeams;
 
@@ -62,6 +66,8 @@ final class MsTeamsRecipient implements BaseModel
     }
 
     /**
+     * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+     *
      * @param MsTeamsShape $msTeams
      */
     public function withMsTeams(

--- a/src/SendToMsTeamsChannelID.php
+++ b/src/SendToMsTeamsChannelID.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Courier;
 
+use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 
 /**
+ * Sends directly to a Microsoft Teams channel by its Bot Framework ID. Still provide at least one of `tenant_id` or `service_url` — sends without either have failed Bot Framework authentication in testing.
+ *
  * @phpstan-type SendToMsTeamsChannelIDShape = array{
- *   channelID: string, serviceURL: string, tenantID: string
+ *   channelID: string, serviceURL?: string|null, tenantID?: string|null
  * }
  */
 final class SendToMsTeamsChannelID implements BaseModel
@@ -21,27 +24,24 @@ final class SendToMsTeamsChannelID implements BaseModel
     #[Required('channel_id')]
     public string $channelID;
 
-    #[Required('service_url')]
-    public string $serviceURL;
+    #[Optional('service_url')]
+    public ?string $serviceURL;
 
-    #[Required('tenant_id')]
-    public string $tenantID;
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
 
     /**
      * `new SendToMsTeamsChannelID()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * SendToMsTeamsChannelID::with(channelID: ..., serviceURL: ..., tenantID: ...)
+     * SendToMsTeamsChannelID::with(channelID: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new SendToMsTeamsChannelID)
-     *   ->withChannelID(...)
-     *   ->withServiceURL(...)
-     *   ->withTenantID(...)
+     * (new SendToMsTeamsChannelID)->withChannelID(...)
      * ```
      */
     public function __construct()
@@ -56,14 +56,15 @@ final class SendToMsTeamsChannelID implements BaseModel
      */
     public static function with(
         string $channelID,
-        string $serviceURL,
-        string $tenantID
+        ?string $serviceURL = null,
+        ?string $tenantID = null
     ): self {
         $self = new self;
 
         $self['channelID'] = $channelID;
-        $self['serviceURL'] = $serviceURL;
-        $self['tenantID'] = $tenantID;
+
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
 
         return $self;
     }

--- a/src/SendToMsTeamsChannelName.php
+++ b/src/SendToMsTeamsChannelName.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Courier;
 
+use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 
 /**
+ * `team_id` is required alongside `channel_name`. Also provide at least one of `tenant_id` or `service_url`; if you provide both, they must agree.
+ *
  * @phpstan-type SendToMsTeamsChannelNameShape = array{
- *   channelName: string, serviceURL: string, teamID: string, tenantID: string
+ *   channelName: string,
+ *   teamID: string,
+ *   serviceURL?: string|null,
+ *   tenantID?: string|null,
  * }
  */
 final class SendToMsTeamsChannelName implements BaseModel
@@ -21,33 +27,27 @@ final class SendToMsTeamsChannelName implements BaseModel
     #[Required('channel_name')]
     public string $channelName;
 
-    #[Required('service_url')]
-    public string $serviceURL;
-
     #[Required('team_id')]
     public string $teamID;
 
-    #[Required('tenant_id')]
-    public string $tenantID;
+    #[Optional('service_url')]
+    public ?string $serviceURL;
+
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
 
     /**
      * `new SendToMsTeamsChannelName()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * SendToMsTeamsChannelName::with(
-     *   channelName: ..., serviceURL: ..., teamID: ..., tenantID: ...
-     * )
+     * SendToMsTeamsChannelName::with(channelName: ..., teamID: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new SendToMsTeamsChannelName)
-     *   ->withChannelName(...)
-     *   ->withServiceURL(...)
-     *   ->withTeamID(...)
-     *   ->withTenantID(...)
+     * (new SendToMsTeamsChannelName)->withChannelName(...)->withTeamID(...)
      * ```
      */
     public function __construct()
@@ -62,16 +62,17 @@ final class SendToMsTeamsChannelName implements BaseModel
      */
     public static function with(
         string $channelName,
-        string $serviceURL,
         string $teamID,
-        string $tenantID
+        ?string $serviceURL = null,
+        ?string $tenantID = null,
     ): self {
         $self = new self;
 
         $self['channelName'] = $channelName;
-        $self['serviceURL'] = $serviceURL;
         $self['teamID'] = $teamID;
-        $self['tenantID'] = $tenantID;
+
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
 
         return $self;
     }
@@ -84,18 +85,18 @@ final class SendToMsTeamsChannelName implements BaseModel
         return $self;
     }
 
-    public function withServiceURL(string $serviceURL): self
-    {
-        $self = clone $this;
-        $self['serviceURL'] = $serviceURL;
-
-        return $self;
-    }
-
     public function withTeamID(string $teamID): self
     {
         $self = clone $this;
         $self['teamID'] = $teamID;
+
+        return $self;
+    }
+
+    public function withServiceURL(string $serviceURL): self
+    {
+        $self = clone $this;
+        $self['serviceURL'] = $serviceURL;
 
         return $self;
     }

--- a/src/SendToMsTeamsEmail.php
+++ b/src/SendToMsTeamsEmail.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Courier;
 
+use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 
 /**
+ * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+ *
  * @phpstan-type SendToMsTeamsEmailShape = array{
- *   email: string, serviceURL: string, tenantID: string
+ *   email: string, serviceURL?: string|null, tenantID?: string|null
  * }
  */
 final class SendToMsTeamsEmail implements BaseModel
@@ -21,24 +24,24 @@ final class SendToMsTeamsEmail implements BaseModel
     #[Required]
     public string $email;
 
-    #[Required('service_url')]
-    public string $serviceURL;
+    #[Optional('service_url')]
+    public ?string $serviceURL;
 
-    #[Required('tenant_id')]
-    public string $tenantID;
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
 
     /**
      * `new SendToMsTeamsEmail()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * SendToMsTeamsEmail::with(email: ..., serviceURL: ..., tenantID: ...)
+     * SendToMsTeamsEmail::with(email: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new SendToMsTeamsEmail)->withEmail(...)->withServiceURL(...)->withTenantID(...)
+     * (new SendToMsTeamsEmail)->withEmail(...)
      * ```
      */
     public function __construct()
@@ -53,14 +56,15 @@ final class SendToMsTeamsEmail implements BaseModel
      */
     public static function with(
         string $email,
-        string $serviceURL,
-        string $tenantID
+        ?string $serviceURL = null,
+        ?string $tenantID = null
     ): self {
         $self = new self;
 
         $self['email'] = $email;
-        $self['serviceURL'] = $serviceURL;
-        $self['tenantID'] = $tenantID;
+
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
 
         return $self;
     }

--- a/src/SendToMsTeamsUserID.php
+++ b/src/SendToMsTeamsUserID.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Courier;
 
+use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 
 /**
+ * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+ *
  * @phpstan-type SendToMsTeamsUserIDShape = array{
- *   serviceURL: string, tenantID: string, userID: string
+ *   userID: string, serviceURL?: string|null, tenantID?: string|null
  * }
  */
 final class SendToMsTeamsUserID implements BaseModel
@@ -18,30 +21,27 @@ final class SendToMsTeamsUserID implements BaseModel
     /** @use SdkModel<SendToMsTeamsUserIDShape> */
     use SdkModel;
 
-    #[Required('service_url')]
-    public string $serviceURL;
-
-    #[Required('tenant_id')]
-    public string $tenantID;
-
     #[Required('user_id')]
     public string $userID;
+
+    #[Optional('service_url')]
+    public ?string $serviceURL;
+
+    #[Optional('tenant_id')]
+    public ?string $tenantID;
 
     /**
      * `new SendToMsTeamsUserID()` is missing required properties by the API.
      *
      * To enforce required parameters use
      * ```
-     * SendToMsTeamsUserID::with(serviceURL: ..., tenantID: ..., userID: ...)
+     * SendToMsTeamsUserID::with(userID: ...)
      * ```
      *
      * Otherwise ensure the following setters are called
      *
      * ```
-     * (new SendToMsTeamsUserID)
-     *   ->withServiceURL(...)
-     *   ->withTenantID(...)
-     *   ->withUserID(...)
+     * (new SendToMsTeamsUserID)->withUserID(...)
      * ```
      */
     public function __construct()
@@ -55,14 +55,23 @@ final class SendToMsTeamsUserID implements BaseModel
      * You must use named parameters to construct any parameters with a default value.
      */
     public static function with(
-        string $serviceURL,
-        string $tenantID,
-        string $userID
+        string $userID,
+        ?string $serviceURL = null,
+        ?string $tenantID = null
     ): self {
         $self = new self;
 
-        $self['serviceURL'] = $serviceURL;
-        $self['tenantID'] = $tenantID;
+        $self['userID'] = $userID;
+
+        null !== $serviceURL && $self['serviceURL'] = $serviceURL;
+        null !== $tenantID && $self['tenantID'] = $tenantID;
+
+        return $self;
+    }
+
+    public function withUserID(string $userID): self
+    {
+        $self = clone $this;
         $self['userID'] = $userID;
 
         return $self;
@@ -80,14 +89,6 @@ final class SendToMsTeamsUserID implements BaseModel
     {
         $self = clone $this;
         $self['tenantID'] = $tenantID;
-
-        return $self;
-    }
-
-    public function withUserID(string $userID): self
-    {
-        $self = clone $this;
-        $self['userID'] = $userID;
 
         return $self;
     }

--- a/src/UserProfile.php
+++ b/src/UserProfile.php
@@ -140,7 +140,11 @@ final class UserProfile implements BaseModel
     #[Optional('middle_name', nullable: true)]
     public ?string $middleName;
 
-    /** @var MsTeamsVariants|null $msTeams */
+    /**
+     * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+     *
+     * @var MsTeamsVariants|null $msTeams
+     */
     #[Optional('ms_teams', nullable: true)]
     public SendToMsTeamsUserID|SendToMsTeamsEmail|SendToMsTeamsChannelID|SendToMsTeamsConversationID|SendToMsTeamsChannelName|null $msTeams;
 
@@ -454,6 +458,8 @@ final class UserProfile implements BaseModel
     }
 
     /**
+     * Provide at least one of `tenant_id` or `service_url`. If you provide both, they must agree.
+     *
      * @param MsTeamsShape|null $msTeams
      */
     public function withMsTeams(

--- a/tests/Services/JourneysTest.php
+++ b/tests/Services/JourneysTest.php
@@ -77,7 +77,17 @@ final class JourneysTest extends TestCase
                         'template' => 'nt_01kx4h2jdafq8bk9aftxak4b40',
                         'to' => [
                             'emailOverride' => 'x',
+                            'msTeams' => [
+                                'channelID' => 'x',
+                                'channelName' => 'x',
+                                'email' => 'x',
+                                'serviceURL' => 'x',
+                                'teamID' => 'x',
+                                'tenantID' => 'x',
+                                'userID' => 'x',
+                            ],
                             'phoneNumberOverride' => 'x',
+                            'slack' => ['channel' => 'x', 'accessToken' => 'x'],
                             'userIDOverride' => 'x',
                         ],
                     ],


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

17 files changed, 672 insertions(+), 97 deletions(-)

<details><summary>Files</summary>

```
 src/Client.php                                 |   2 +-
 src/Journeys/JourneySendNode/Message.php       |   5 ++
 src/Journeys/JourneySendNode/Message/To.php    |  60 +++++++++++++++
 src/Journeys/JourneySendNodeToMsTeams.php      | 179 +++++++++++++++++++++++++++++++++++++++++++++
 src/Journeys/JourneySendNodeToSlack.php        |  36 +++++++++
 src/Journeys/JourneySendNodeToSlackChannel.php |  92 +++++++++++++++++++++++
 src/Journeys/JourneySendNodeToSlackEmail.php   |  90 +++++++++++++++++++++++
 src/Journeys/JourneySendNodeToSlackUserID.php  |  92 +++++++++++++++++++++++
 src/MsTeams.php                                |   2 +
 src/MsTeamsBaseProperties.php                  |  38 ++++------
 src/MsTeamsRecipient.php                       |   8 +-
 src/SendToMsTeamsChannelID.php                 |  29 ++++----
 src/SendToMsTeamsChannelName.php               |  45 ++++++------
 src/SendToMsTeamsEmail.php                     |  26 ++++---
 src/SendToMsTeamsUserID.php                    |  47 ++++++------
 src/UserProfile.php                            |   8 +-
 tests/Services/JourneysTest.php                |  10 +++
 17 files changed, 672 insertions(+), 97 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
