### PR TITLE
feat(api): document channel on journey send nodes [C-20309]

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '7.1.0',
+            'X-Stainless-Package-Version' => '7.2.0',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/Journeys/JourneySendNode.php
+++ b/src/Journeys/JourneySendNode.php
@@ -8,6 +8,7 @@ use Courier\Core\Attributes\Optional;
 use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
+use Courier\Journeys\JourneySendNode\Channel;
 use Courier\Journeys\JourneySendNode\Message;
 use Courier\Journeys\JourneySendNode\Type;
 
@@ -23,6 +24,7 @@ use Courier\Journeys\JourneySendNode\Type;
  *   message: Message|MessageShape,
  *   type: Type|value-of<Type>,
  *   id?: string|null,
+ *   channel?: null|Channel|value-of<Channel>,
  *   conditions?: JourneyConditionsFieldShape|null,
  *   experiment?: null|JourneyExperiment|JourneyExperimentShape,
  * }
@@ -41,6 +43,14 @@ final class JourneySendNode implements BaseModel
 
     #[Optional]
     public ?string $id;
+
+    /**
+     * The channel this node sends through. Optional — when omitted, the field is absent from the node, including on `GET`; nodes created before this field existed have it unset. Setting it makes the node's channel explicit to any client reading the journey.
+     *
+     * @var value-of<Channel>|null $channel
+     */
+    #[Optional(enum: Channel::class)]
+    public ?string $channel;
 
     /**
      * Condition spec for a journey node. Accepts a single condition atom, an AND/OR group, or an AND/OR nested group. Omit the `conditions` property entirely to express "no conditions".
@@ -82,6 +92,7 @@ final class JourneySendNode implements BaseModel
      *
      * @param Message|MessageShape $message
      * @param Type|value-of<Type> $type
+     * @param Channel|value-of<Channel>|null $channel
      * @param JourneyConditionsFieldShape|null $conditions
      * @param JourneyExperiment|JourneyExperimentShape|null $experiment
      */
@@ -89,6 +100,7 @@ final class JourneySendNode implements BaseModel
         Message|array $message,
         Type|string $type,
         ?string $id = null,
+        Channel|string|null $channel = null,
         array|JourneyConditionGroup|JourneyConditionNestedGroup|null $conditions = null,
         JourneyExperiment|array|null $experiment = null,
     ): self {
@@ -98,6 +110,7 @@ final class JourneySendNode implements BaseModel
         $self['type'] = $type;
 
         null !== $id && $self['id'] = $id;
+        null !== $channel && $self['channel'] = $channel;
         null !== $conditions && $self['conditions'] = $conditions;
         null !== $experiment && $self['experiment'] = $experiment;
 
@@ -130,6 +143,19 @@ final class JourneySendNode implements BaseModel
     {
         $self = clone $this;
         $self['id'] = $id;
+
+        return $self;
+    }
+
+    /**
+     * The channel this node sends through. Optional — when omitted, the field is absent from the node, including on `GET`; nodes created before this field existed have it unset. Setting it makes the node's channel explicit to any client reading the journey.
+     *
+     * @param Channel|value-of<Channel> $channel
+     */
+    public function withChannel(Channel|string $channel): self
+    {
+        $self = clone $this;
+        $self['channel'] = $channel;
 
         return $self;
     }

--- a/src/Journeys/JourneySendNode/Channel.php
+++ b/src/Journeys/JourneySendNode/Channel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\Journeys\JourneySendNode;
+
+/**
+ * The channel this node sends through. Optional — when omitted, the field is absent from the node, including on `GET`; nodes created before this field existed have it unset. Setting it makes the node's channel explicit to any client reading the journey.
+ */
+enum Channel: string
+{
+    case EMAIL = 'email';
+
+    case SMS = 'sms';
+
+    case PUSH = 'push';
+
+    case INBOX = 'inbox';
+
+    case SLACK = 'slack';
+
+    case MSTEAMS = 'msteams';
+}

--- a/tests/Services/JourneysTest.php
+++ b/tests/Services/JourneysTest.php
@@ -93,6 +93,7 @@ final class JourneysTest extends TestCase
                     ],
                     'type' => 'send',
                     'id' => 'send-1',
+                    'channel' => 'email',
                     'conditions' => ['string', 'string'],
                     'experiment' => [
                         'bucketingKey' => 'x',


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

4 files changed, 51 insertions(+), 1 deletion(-)

<details><summary>Files</summary>

```
 src/Client.php                           |  2 +-
 src/Journeys/JourneySendNode.php         | 26 ++++++++++++++++++++++++++
 src/Journeys/JourneySendNode/Channel.php | 23 +++++++++++++++++++++++
 tests/Services/JourneysTest.php          |  1 +
 4 files changed, 51 insertions(+), 1 deletion(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
