### PR TITLE
fix(api): correct two Elemental field names the REST API rejects

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '7.2.0',
+            'X-Stainless-Package-Version' => '7.3.1',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/ElementalImageNode.php
+++ b/src/ElementalImageNode.php
@@ -58,7 +58,7 @@ final class ElementalImageNode implements BaseModel
     /**
      * Alternate text for the image.
      */
-    #[Optional(nullable: true)]
+    #[Optional('alt_text', nullable: true)]
     public ?string $altText;
 
     /**

--- a/src/ElementalImageNodeWithType.php
+++ b/src/ElementalImageNodeWithType.php
@@ -60,7 +60,7 @@ final class ElementalImageNodeWithType implements BaseModel
     /**
      * Alternate text for the image.
      */
-    #[Optional(nullable: true)]
+    #[Optional('alt_text', nullable: true)]
     public ?string $altText;
 
     /**

--- a/src/ElementalQuoteNode.php
+++ b/src/ElementalQuoteNode.php
@@ -59,7 +59,7 @@ final class ElementalQuoteNode implements BaseModel
     /**
      * CSS border color property. For example, `#fff`.
      */
-    #[Optional(nullable: true)]
+    #[Optional('border_color', nullable: true)]
     public ?string $borderColor;
 
     /**

--- a/src/ElementalQuoteNodeWithType.php
+++ b/src/ElementalQuoteNodeWithType.php
@@ -61,7 +61,7 @@ final class ElementalQuoteNodeWithType implements BaseModel
     /**
      * CSS border color property. For example, `#fff`.
      */
-    #[Optional(nullable: true)]
+    #[Optional('border_color', nullable: true)]
     public ?string $borderColor;
 
     /**


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

5 files changed, 5 insertions(+), 5 deletions(-)

<details><summary>Files</summary>

```
 src/Client.php                     | 2 +-
 src/ElementalImageNode.php         | 2 +-
 src/ElementalImageNodeWithType.php | 2 +-
 src/ElementalQuoteNode.php         | 2 +-
 src/ElementalQuoteNodeWithType.php | 2 +-
 5 files changed, 5 insertions(+), 5 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
