### PR TITLE
fix(api): text content is not required

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '7.3.1',
+            'X-Stainless-Package-Version' => '7.3.2',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/ElementalTextNode.php
+++ b/src/ElementalTextNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Courier;
 
 use Courier\Core\Attributes\Optional;
-use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 use Courier\ElementalTextNode\Align;
@@ -21,10 +20,10 @@ use Courier\ElementalTextNode\Format;
  *   if?: string|null,
  *   loop?: string|null,
  *   ref?: string|null,
- *   content: string,
  *   align?: null|Align|value-of<Align>,
  *   bold?: string|null,
  *   color?: string|null,
+ *   content?: string|null,
  *   fontSize?: string|null,
  *   format?: null|Format|value-of<Format>,
  *   italic?: string|null,
@@ -54,13 +53,6 @@ final class ElementalTextNode implements BaseModel
     public ?string $ref;
 
     /**
-     * The text content displayed in the notification. Either this
-     * field must be specified, or the elements field.
-     */
-    #[Required]
-    public string $content;
-
-    /**
      * Text alignment.
      *
      * @var value-of<Align>|null $align
@@ -79,6 +71,13 @@ final class ElementalTextNode implements BaseModel
      */
     #[Optional(nullable: true)]
     public ?string $color;
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    #[Optional]
+    public ?string $content;
 
     /**
      * CSS px font size for this text block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
@@ -126,20 +125,6 @@ final class ElementalTextNode implements BaseModel
     #[Optional(nullable: true)]
     public ?string $underline;
 
-    /**
-     * `new ElementalTextNode()` is missing required properties by the API.
-     *
-     * To enforce required parameters use
-     * ```
-     * ElementalTextNode::with(content: ...)
-     * ```
-     *
-     * Otherwise ensure the following setters are called
-     *
-     * ```
-     * (new ElementalTextNode)->withContent(...)
-     * ```
-     */
     public function __construct()
     {
         $this->initialize();
@@ -157,7 +142,6 @@ final class ElementalTextNode implements BaseModel
      * @param TextStyle|value-of<TextStyle>|null $textStyle
      */
     public static function with(
-        string $content,
         ?array $channels = null,
         ?string $if = null,
         ?string $loop = null,
@@ -165,6 +149,7 @@ final class ElementalTextNode implements BaseModel
         Align|string|null $align = null,
         ?string $bold = null,
         ?string $color = null,
+        ?string $content = null,
         ?string $fontSize = null,
         Format|string|null $format = null,
         ?string $italic = null,
@@ -176,8 +161,6 @@ final class ElementalTextNode implements BaseModel
     ): self {
         $self = new self;
 
-        $self['content'] = $content;
-
         null !== $channels && $self['channels'] = $channels;
         null !== $if && $self['if'] = $if;
         null !== $loop && $self['loop'] = $loop;
@@ -185,6 +168,7 @@ final class ElementalTextNode implements BaseModel
         null !== $align && $self['align'] = $align;
         null !== $bold && $self['bold'] = $bold;
         null !== $color && $self['color'] = $color;
+        null !== $content && $self['content'] = $content;
         null !== $fontSize && $self['fontSize'] = $fontSize;
         null !== $format && $self['format'] = $format;
         null !== $italic && $self['italic'] = $italic;
@@ -233,18 +217,6 @@ final class ElementalTextNode implements BaseModel
     }
 
     /**
-     * The text content displayed in the notification. Either this
-     * field must be specified, or the elements field.
-     */
-    public function withContent(string $content): self
-    {
-        $self = clone $this;
-        $self['content'] = $content;
-
-        return $self;
-    }
-
-    /**
      * Text alignment.
      *
      * @param Align|value-of<Align> $align
@@ -275,6 +247,18 @@ final class ElementalTextNode implements BaseModel
     {
         $self = clone $this;
         $self['color'] = $color;
+
+        return $self;
+    }
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
 
         return $self;
     }

--- a/src/ElementalTextNodeWithType.php
+++ b/src/ElementalTextNodeWithType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Courier;
 
 use Courier\Core\Attributes\Optional;
-use Courier\Core\Attributes\Required;
 use Courier\Core\Concerns\SdkModel;
 use Courier\Core\Contracts\BaseModel;
 use Courier\ElementalTextNode\Align;
@@ -22,10 +21,10 @@ use Courier\ElementalTextNodeWithType\Type;
  *   if?: string|null,
  *   loop?: string|null,
  *   ref?: string|null,
- *   content: string,
  *   align?: null|Align|value-of<Align>,
  *   bold?: string|null,
  *   color?: string|null,
+ *   content?: string|null,
  *   fontSize?: string|null,
  *   format?: null|Format|value-of<Format>,
  *   italic?: string|null,
@@ -56,13 +55,6 @@ final class ElementalTextNodeWithType implements BaseModel
     public ?string $ref;
 
     /**
-     * The text content displayed in the notification. Either this
-     * field must be specified, or the elements field.
-     */
-    #[Required]
-    public string $content;
-
-    /**
      * Text alignment.
      *
      * @var value-of<Align>|null $align
@@ -81,6 +73,13 @@ final class ElementalTextNodeWithType implements BaseModel
      */
     #[Optional(nullable: true)]
     public ?string $color;
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    #[Optional]
+    public ?string $content;
 
     /**
      * CSS px font size for this text block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
@@ -132,20 +131,6 @@ final class ElementalTextNodeWithType implements BaseModel
     #[Optional(enum: Type::class)]
     public ?string $type;
 
-    /**
-     * `new ElementalTextNodeWithType()` is missing required properties by the API.
-     *
-     * To enforce required parameters use
-     * ```
-     * ElementalTextNodeWithType::with(content: ...)
-     * ```
-     *
-     * Otherwise ensure the following setters are called
-     *
-     * ```
-     * (new ElementalTextNodeWithType)->withContent(...)
-     * ```
-     */
     public function __construct()
     {
         $this->initialize();
@@ -164,7 +149,6 @@ final class ElementalTextNodeWithType implements BaseModel
      * @param Type|value-of<Type>|null $type
      */
     public static function with(
-        string $content,
         ?array $channels = null,
         ?string $if = null,
         ?string $loop = null,
@@ -172,6 +156,7 @@ final class ElementalTextNodeWithType implements BaseModel
         Align|string|null $align = null,
         ?string $bold = null,
         ?string $color = null,
+        ?string $content = null,
         ?string $fontSize = null,
         Format|string|null $format = null,
         ?string $italic = null,
@@ -184,8 +169,6 @@ final class ElementalTextNodeWithType implements BaseModel
     ): self {
         $self = new self;
 
-        $self['content'] = $content;
-
         null !== $channels && $self['channels'] = $channels;
         null !== $if && $self['if'] = $if;
         null !== $loop && $self['loop'] = $loop;
@@ -193,6 +176,7 @@ final class ElementalTextNodeWithType implements BaseModel
         null !== $align && $self['align'] = $align;
         null !== $bold && $self['bold'] = $bold;
         null !== $color && $self['color'] = $color;
+        null !== $content && $self['content'] = $content;
         null !== $fontSize && $self['fontSize'] = $fontSize;
         null !== $format && $self['format'] = $format;
         null !== $italic && $self['italic'] = $italic;
@@ -242,18 +226,6 @@ final class ElementalTextNodeWithType implements BaseModel
     }
 
     /**
-     * The text content displayed in the notification. Either this
-     * field must be specified, or the elements field.
-     */
-    public function withContent(string $content): self
-    {
-        $self = clone $this;
-        $self['content'] = $content;
-
-        return $self;
-    }
-
-    /**
      * Text alignment.
      *
      * @param Align|value-of<Align> $align
@@ -284,6 +256,18 @@ final class ElementalTextNodeWithType implements BaseModel
     {
         $self = clone $this;
         $self['color'] = $color;
+
+        return $self;
+    }
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
 
         return $self;
     }


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 45 insertions(+), 77 deletions(-)

<details><summary>Files</summary>

```
 src/Client.php                    |  2 +-
 src/ElementalTextNode.php         | 60 ++++++++++++++++++++++-------------------------------------
 src/ElementalTextNodeWithType.php | 60 ++++++++++++++++++++++-------------------------------------
 3 files changed, 45 insertions(+), 77 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
