### PR TITLE
docs(api): document the channel-block requirement on template creation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,7 +183,7 @@ class Client extends BaseClient
             'Accept' => 'application/json',
             'User-Agent' => sprintf('Courier/PHP %s', VERSION),
             'X-Stainless-Lang' => 'php',
-            'X-Stainless-Package-Version' => '7.3.2',
+            'X-Stainless-Package-Version' => '7.3.3',
             'X-Stainless-Arch' => Util::machtype(),
             'X-Stainless-OS' => Util::ostype(),
             'X-Stainless-Runtime' => php_sapi_name(),

--- a/src/ElementalChannelNode.php
+++ b/src/ElementalChannelNode.php
@@ -11,12 +11,16 @@ use Courier\Core\Contracts\BaseModel;
 /**
  * The channel element allows a notification to be customized based on which channel it is sent through.  For example, you may want to display a detailed message when the notification is sent through email,  and a more concise message in a push notification. Channel elements are only valid as top-level  elements; you cannot nest channel elements. If there is a channel element specified at the top-level  of the document, all sibling elements must be channel elements. Note: As an alternative, most elements support a `channel` property. Which allows you to selectively  display an individual element on a per channel basis. See the  [control flow docs](https://www.courier.com/docs/platform/content/elemental/control-flow/) for more details.
  *
+ * @phpstan-import-type ElementalNodeNonChannelVariants from \Courier\ElementalNodeNonChannel
+ * @phpstan-import-type ElementalNodeNonChannelShape from \Courier\ElementalNodeNonChannel
+ *
  * @phpstan-type ElementalChannelNodeShape = array{
  *   channels?: list<string>|null,
  *   if?: string|null,
  *   loop?: string|null,
  *   ref?: string|null,
  *   channel?: string|null,
+ *   elements?: list<ElementalNodeNonChannelShape>|null,
  *   fontSize?: string|null,
  *   lineHeight?: string|null,
  *   padding?: string|null,
@@ -46,6 +50,16 @@ final class ElementalChannelNode implements BaseModel
      */
     #[Optional]
     public ?string $channel;
+
+    /**
+     * An array of elements to apply to the channel. If `raw` has not been
+     * specified, `elements` is `required`. Channel elements cannot nest, so
+     * these are any node except another channel block.
+     *
+     * @var list<ElementalNodeNonChannelVariants>|null $elements
+     */
+    #[Optional(list: ElementalNodeNonChannel::class, nullable: true)]
+    public ?array $elements;
 
     /**
      * Email only. Document-level base font size (CSS px, e.g. `16px`) for body content — text, quote, list and action button labels. Heading styles (`h1`/`h2`/`h3`) and `subtext` keep their preset sizes.
@@ -84,6 +98,7 @@ final class ElementalChannelNode implements BaseModel
      * You must use named parameters to construct any parameters with a default value.
      *
      * @param list<string>|null $channels
+     * @param list<ElementalNodeNonChannelShape>|null $elements
      * @param array<string,mixed>|null $raw
      */
     public static function with(
@@ -92,6 +107,7 @@ final class ElementalChannelNode implements BaseModel
         ?string $loop = null,
         ?string $ref = null,
         ?string $channel = null,
+        ?array $elements = null,
         ?string $fontSize = null,
         ?string $lineHeight = null,
         ?string $padding = null,
@@ -104,6 +120,7 @@ final class ElementalChannelNode implements BaseModel
         null !== $loop && $self['loop'] = $loop;
         null !== $ref && $self['ref'] = $ref;
         null !== $channel && $self['channel'] = $channel;
+        null !== $elements && $self['elements'] = $elements;
         null !== $fontSize && $self['fontSize'] = $fontSize;
         null !== $lineHeight && $self['lineHeight'] = $lineHeight;
         null !== $padding && $self['padding'] = $padding;
@@ -154,6 +171,21 @@ final class ElementalChannelNode implements BaseModel
     {
         $self = clone $this;
         $self['channel'] = $channel;
+
+        return $self;
+    }
+
+    /**
+     * An array of elements to apply to the channel. If `raw` has not been
+     * specified, `elements` is `required`. Channel elements cannot nest, so
+     * these are any node except another channel block.
+     *
+     * @param list<ElementalNodeNonChannelShape>|null $elements
+     */
+    public function withElements(?array $elements): self
+    {
+        $self = clone $this;
+        $self['elements'] = $elements;
 
         return $self;
     }

--- a/src/ElementalChannelNodeWithType.php
+++ b/src/ElementalChannelNodeWithType.php
@@ -12,12 +12,16 @@ use Courier\ElementalChannelNodeWithType\Type;
 /**
  * The channel element allows a notification to be customized based on which channel it is sent through.  For example, you may want to display a detailed message when the notification is sent through email,  and a more concise message in a push notification. Channel elements are only valid as top-level  elements; you cannot nest channel elements. If there is a channel element specified at the top-level  of the document, all sibling elements must be channel elements. Note: As an alternative, most elements support a `channel` property. Which allows you to selectively  display an individual element on a per channel basis. See the  [control flow docs](https://www.courier.com/docs/platform/content/elemental/control-flow/) for more details.
  *
+ * @phpstan-import-type ElementalNodeNonChannelVariants from \Courier\ElementalNodeNonChannel
+ * @phpstan-import-type ElementalNodeNonChannelShape from \Courier\ElementalNodeNonChannel
+ *
  * @phpstan-type ElementalChannelNodeWithTypeShape = array{
  *   channels?: list<string>|null,
  *   if?: string|null,
  *   loop?: string|null,
  *   ref?: string|null,
  *   channel?: string|null,
+ *   elements?: list<ElementalNodeNonChannelShape>|null,
  *   fontSize?: string|null,
  *   lineHeight?: string|null,
  *   padding?: string|null,
@@ -48,6 +52,16 @@ final class ElementalChannelNodeWithType implements BaseModel
      */
     #[Optional]
     public ?string $channel;
+
+    /**
+     * An array of elements to apply to the channel. If `raw` has not been
+     * specified, `elements` is `required`. Channel elements cannot nest, so
+     * these are any node except another channel block.
+     *
+     * @var list<ElementalNodeNonChannelVariants>|null $elements
+     */
+    #[Optional(list: ElementalNodeNonChannel::class, nullable: true)]
+    public ?array $elements;
 
     /**
      * Email only. Document-level base font size (CSS px, e.g. `16px`) for body content — text, quote, list and action button labels. Heading styles (`h1`/`h2`/`h3`) and `subtext` keep their preset sizes.
@@ -90,6 +104,7 @@ final class ElementalChannelNodeWithType implements BaseModel
      * You must use named parameters to construct any parameters with a default value.
      *
      * @param list<string>|null $channels
+     * @param list<ElementalNodeNonChannelShape>|null $elements
      * @param array<string,mixed>|null $raw
      * @param Type|value-of<Type>|null $type
      */
@@ -99,6 +114,7 @@ final class ElementalChannelNodeWithType implements BaseModel
         ?string $loop = null,
         ?string $ref = null,
         ?string $channel = null,
+        ?array $elements = null,
         ?string $fontSize = null,
         ?string $lineHeight = null,
         ?string $padding = null,
@@ -112,6 +128,7 @@ final class ElementalChannelNodeWithType implements BaseModel
         null !== $loop && $self['loop'] = $loop;
         null !== $ref && $self['ref'] = $ref;
         null !== $channel && $self['channel'] = $channel;
+        null !== $elements && $self['elements'] = $elements;
         null !== $fontSize && $self['fontSize'] = $fontSize;
         null !== $lineHeight && $self['lineHeight'] = $lineHeight;
         null !== $padding && $self['padding'] = $padding;
@@ -163,6 +180,21 @@ final class ElementalChannelNodeWithType implements BaseModel
     {
         $self = clone $this;
         $self['channel'] = $channel;
+
+        return $self;
+    }
+
+    /**
+     * An array of elements to apply to the channel. If `raw` has not been
+     * specified, `elements` is `required`. Channel elements cannot nest, so
+     * these are any node except another channel block.
+     *
+     * @param list<ElementalNodeNonChannelShape>|null $elements
+     */
+    public function withElements(?array $elements): self
+    {
+        $self = clone $this;
+        $self['elements'] = $elements;
 
         return $self;
     }

--- a/src/ElementalNodeNonChannel.php
+++ b/src/ElementalNodeNonChannel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier;
+
+use Courier\Core\Concerns\SdkUnion;
+use Courier\Core\Conversion\Contracts\Converter;
+use Courier\Core\Conversion\Contracts\ConverterSource;
+use Courier\ElementalNodeNonChannel\UnionMember0;
+use Courier\ElementalNodeNonChannel\UnionMember1;
+use Courier\ElementalNodeNonChannel\UnionMember2;
+use Courier\ElementalNodeNonChannel\UnionMember3;
+use Courier\ElementalNodeNonChannel\UnionMember4;
+use Courier\ElementalNodeNonChannel\UnionMember5;
+use Courier\ElementalNodeNonChannel\UnionMember6;
+
+/**
+ * Any Elemental node except a channel block. Channel elements are only valid as top-level elements, so the `elements` nested inside one can never be another channel. Keeping this union channel-free also keeps the schema acyclic; a recursive `$ref` here breaks the generated Python models.
+ *
+ * @phpstan-import-type UnionMember0Shape from \Courier\ElementalNodeNonChannel\UnionMember0
+ * @phpstan-import-type UnionMember1Shape from \Courier\ElementalNodeNonChannel\UnionMember1
+ * @phpstan-import-type UnionMember2Shape from \Courier\ElementalNodeNonChannel\UnionMember2
+ * @phpstan-import-type UnionMember3Shape from \Courier\ElementalNodeNonChannel\UnionMember3
+ * @phpstan-import-type UnionMember4Shape from \Courier\ElementalNodeNonChannel\UnionMember4
+ * @phpstan-import-type UnionMember5Shape from \Courier\ElementalNodeNonChannel\UnionMember5
+ * @phpstan-import-type UnionMember6Shape from \Courier\ElementalNodeNonChannel\UnionMember6
+ *
+ * @phpstan-type ElementalNodeNonChannelVariants = UnionMember0|UnionMember1|UnionMember2|UnionMember3|UnionMember4|UnionMember5|UnionMember6
+ * @phpstan-type ElementalNodeNonChannelShape = ElementalNodeNonChannelVariants|UnionMember0Shape|UnionMember1Shape|UnionMember2Shape|UnionMember3Shape|UnionMember4Shape|UnionMember5Shape|UnionMember6Shape
+ */
+final class ElementalNodeNonChannel implements ConverterSource
+{
+    use SdkUnion;
+
+    /**
+     * @return list<string|Converter|ConverterSource>|array<string,string|Converter|ConverterSource>
+     */
+    public static function variants(): array
+    {
+        return [
+            UnionMember0::class,
+            UnionMember1::class,
+            UnionMember2::class,
+            UnionMember3::class,
+            UnionMember4::class,
+            UnionMember5::class,
+            UnionMember6::class,
+        ];
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember0.php
+++ b/src/ElementalNodeNonChannel/UnionMember0.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember0\Type;
+use Courier\ElementalTextNode\Align;
+use Courier\ElementalTextNode\Format;
+use Courier\LocaleItem;
+use Courier\TextStyle;
+
+/**
+ * Represents a body of text to be rendered inside of the notification.
+ *
+ * @phpstan-import-type LocaleItemShape from \Courier\LocaleItem
+ *
+ * @phpstan-type UnionMember0Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   align?: null|Align|value-of<Align>,
+ *   bold?: string|null,
+ *   color?: string|null,
+ *   content?: string|null,
+ *   fontSize?: string|null,
+ *   format?: null|Format|value-of<Format>,
+ *   italic?: string|null,
+ *   lineHeight?: string|null,
+ *   locales?: array<string,LocaleItem|LocaleItemShape>|null,
+ *   strikethrough?: string|null,
+ *   textStyle?: null|TextStyle|value-of<TextStyle>,
+ *   underline?: string|null,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember0 implements BaseModel
+{
+    /** @use SdkModel<UnionMember0Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * Text alignment.
+     *
+     * @var value-of<Align>|null $align
+     */
+    #[Optional(enum: Align::class)]
+    public ?string $align;
+
+    /**
+     * Apply bold to the text.
+     */
+    #[Optional(nullable: true)]
+    public ?string $bold;
+
+    /**
+     * Specifies the color of text. Can be any valid css color value.
+     */
+    #[Optional(nullable: true)]
+    public ?string $color;
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    #[Optional]
+    public ?string $content;
+
+    /**
+     * CSS px font size for this text block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
+     */
+    #[Optional('font_size', nullable: true)]
+    public ?string $fontSize;
+
+    /** @var value-of<Format>|null $format */
+    #[Optional(enum: Format::class, nullable: true)]
+    public ?string $format;
+
+    /**
+     * Apply italics to the text.
+     */
+    #[Optional(nullable: true)]
+    public ?string $italic;
+
+    /**
+     * CSS line height for this text block, as a px value or a unitless multiplier, e.g. `24px` or `1.5`. Email only.
+     */
+    #[Optional('line_height', nullable: true)]
+    public ?string $lineHeight;
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @var array<string,LocaleItem>|null $locales
+     */
+    #[Optional(map: LocaleItem::class, nullable: true)]
+    public ?array $locales;
+
+    /**
+     * Apply a strike through the text.
+     */
+    #[Optional(nullable: true)]
+    public ?string $strikethrough;
+
+    /** @var value-of<TextStyle>|null $textStyle */
+    #[Optional('text_style', enum: TextStyle::class)]
+    public ?string $textStyle;
+
+    /**
+     * Apply an underline to the text.
+     */
+    #[Optional(nullable: true)]
+    public ?string $underline;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Align|value-of<Align>|null $align
+     * @param Format|value-of<Format>|null $format
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     * @param TextStyle|value-of<TextStyle>|null $textStyle
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        Align|string|null $align = null,
+        ?string $bold = null,
+        ?string $color = null,
+        ?string $content = null,
+        ?string $fontSize = null,
+        Format|string|null $format = null,
+        ?string $italic = null,
+        ?string $lineHeight = null,
+        ?array $locales = null,
+        ?string $strikethrough = null,
+        TextStyle|string|null $textStyle = null,
+        ?string $underline = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $align && $self['align'] = $align;
+        null !== $bold && $self['bold'] = $bold;
+        null !== $color && $self['color'] = $color;
+        null !== $content && $self['content'] = $content;
+        null !== $fontSize && $self['fontSize'] = $fontSize;
+        null !== $format && $self['format'] = $format;
+        null !== $italic && $self['italic'] = $italic;
+        null !== $lineHeight && $self['lineHeight'] = $lineHeight;
+        null !== $locales && $self['locales'] = $locales;
+        null !== $strikethrough && $self['strikethrough'] = $strikethrough;
+        null !== $textStyle && $self['textStyle'] = $textStyle;
+        null !== $underline && $self['underline'] = $underline;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * Text alignment.
+     *
+     * @param Align|value-of<Align> $align
+     */
+    public function withAlign(Align|string $align): self
+    {
+        $self = clone $this;
+        $self['align'] = $align;
+
+        return $self;
+    }
+
+    /**
+     * Apply bold to the text.
+     */
+    public function withBold(?string $bold): self
+    {
+        $self = clone $this;
+        $self['bold'] = $bold;
+
+        return $self;
+    }
+
+    /**
+     * Specifies the color of text. Can be any valid css color value.
+     */
+    public function withColor(?string $color): self
+    {
+        $self = clone $this;
+        $self['color'] = $color;
+
+        return $self;
+    }
+
+    /**
+     * The text content displayed in the notification. Either this
+     * field must be specified, or the elements field.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
+
+        return $self;
+    }
+
+    /**
+     * CSS px font size for this text block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
+     */
+    public function withFontSize(?string $fontSize): self
+    {
+        $self = clone $this;
+        $self['fontSize'] = $fontSize;
+
+        return $self;
+    }
+
+    /**
+     * @param Format|value-of<Format>|null $format
+     */
+    public function withFormat(Format|string|null $format): self
+    {
+        $self = clone $this;
+        $self['format'] = $format;
+
+        return $self;
+    }
+
+    /**
+     * Apply italics to the text.
+     */
+    public function withItalic(?string $italic): self
+    {
+        $self = clone $this;
+        $self['italic'] = $italic;
+
+        return $self;
+    }
+
+    /**
+     * CSS line height for this text block, as a px value or a unitless multiplier, e.g. `24px` or `1.5`. Email only.
+     */
+    public function withLineHeight(?string $lineHeight): self
+    {
+        $self = clone $this;
+        $self['lineHeight'] = $lineHeight;
+
+        return $self;
+    }
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     */
+    public function withLocales(?array $locales): self
+    {
+        $self = clone $this;
+        $self['locales'] = $locales;
+
+        return $self;
+    }
+
+    /**
+     * Apply a strike through the text.
+     */
+    public function withStrikethrough(?string $strikethrough): self
+    {
+        $self = clone $this;
+        $self['strikethrough'] = $strikethrough;
+
+        return $self;
+    }
+
+    /**
+     * @param TextStyle|value-of<TextStyle> $textStyle
+     */
+    public function withTextStyle(TextStyle|string $textStyle): self
+    {
+        $self = clone $this;
+        $self['textStyle'] = $textStyle;
+
+        return $self;
+    }
+
+    /**
+     * Apply an underline to the text.
+     */
+    public function withUnderline(?string $underline): self
+    {
+        $self = clone $this;
+        $self['underline'] = $underline;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember0/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember0/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember0;
+
+enum Type: string
+{
+    case TEXT = 'text';
+}

--- a/src/ElementalNodeNonChannel/UnionMember1.php
+++ b/src/ElementalNodeNonChannel/UnionMember1.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember1\Type;
+
+/**
+ * The meta element contains information describing the notification that may  be used by a particular channel or provider. One important field is the title  field which will be used as the title for channels that support it.
+ *
+ * @phpstan-type UnionMember1Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   title?: string|null,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember1 implements BaseModel
+{
+    /** @use SdkModel<UnionMember1Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * The title to be displayed by supported channels. For example, the email subject.
+     */
+    #[Optional(nullable: true)]
+    public ?string $title;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        ?string $title = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $title && $self['title'] = $title;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * The title to be displayed by supported channels. For example, the email subject.
+     */
+    public function withTitle(?string $title): self
+    {
+        $self = clone $this;
+        $self['title'] = $title;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember1/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember1/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember1;
+
+enum Type: string
+{
+    case META = 'meta';
+}

--- a/src/ElementalNodeNonChannel/UnionMember2.php
+++ b/src/ElementalNodeNonChannel/UnionMember2.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Alignment;
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember2\Type;
+
+/**
+ * Used to embed an image into the notification.
+ *
+ * @phpstan-type UnionMember2Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   src: string,
+ *   align?: null|Alignment|value-of<Alignment>,
+ *   altText?: string|null,
+ *   borderColor?: string|null,
+ *   borderSize?: string|null,
+ *   href?: string|null,
+ *   padding?: string|null,
+ *   width?: string|null,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember2 implements BaseModel
+{
+    /** @use SdkModel<UnionMember2Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * The source of the image.
+     */
+    #[Required]
+    public string $src;
+
+    /** @var value-of<Alignment>|null $align */
+    #[Optional(enum: Alignment::class)]
+    public ?string $align;
+
+    /**
+     * Alternate text for the image.
+     */
+    #[Optional('alt_text', nullable: true)]
+    public ?string $altText;
+
+    /**
+     * CSS border color applied to the image. For example, `#ccc`.
+     */
+    #[Optional('border_color', nullable: true)]
+    public ?string $borderColor;
+
+    /**
+     * CSS border width applied to the image. For example, `1px`.
+     */
+    #[Optional('border_size', nullable: true)]
+    public ?string $borderSize;
+
+    /**
+     * A URL to link to when the image is clicked.
+     */
+    #[Optional(nullable: true)]
+    public ?string $href;
+
+    /**
+     * CSS padding applied around the image. For example, `10px`.
+     */
+    #[Optional(nullable: true)]
+    public ?string $padding;
+
+    /**
+     * CSS width properties to apply to the image. For example, 50px.
+     */
+    #[Optional(nullable: true)]
+    public ?string $width;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    /**
+     * `new UnionMember2()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * UnionMember2::with(src: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new UnionMember2)->withSrc(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Alignment|value-of<Alignment>|null $align
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        string $src,
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        Alignment|string|null $align = null,
+        ?string $altText = null,
+        ?string $borderColor = null,
+        ?string $borderSize = null,
+        ?string $href = null,
+        ?string $padding = null,
+        ?string $width = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        $self['src'] = $src;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $align && $self['align'] = $align;
+        null !== $altText && $self['altText'] = $altText;
+        null !== $borderColor && $self['borderColor'] = $borderColor;
+        null !== $borderSize && $self['borderSize'] = $borderSize;
+        null !== $href && $self['href'] = $href;
+        null !== $padding && $self['padding'] = $padding;
+        null !== $width && $self['width'] = $width;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * The source of the image.
+     */
+    public function withSrc(string $src): self
+    {
+        $self = clone $this;
+        $self['src'] = $src;
+
+        return $self;
+    }
+
+    /**
+     * @param Alignment|value-of<Alignment> $align
+     */
+    public function withAlign(Alignment|string $align): self
+    {
+        $self = clone $this;
+        $self['align'] = $align;
+
+        return $self;
+    }
+
+    /**
+     * Alternate text for the image.
+     */
+    public function withAltText(?string $altText): self
+    {
+        $self = clone $this;
+        $self['altText'] = $altText;
+
+        return $self;
+    }
+
+    /**
+     * CSS border color applied to the image. For example, `#ccc`.
+     */
+    public function withBorderColor(?string $borderColor): self
+    {
+        $self = clone $this;
+        $self['borderColor'] = $borderColor;
+
+        return $self;
+    }
+
+    /**
+     * CSS border width applied to the image. For example, `1px`.
+     */
+    public function withBorderSize(?string $borderSize): self
+    {
+        $self = clone $this;
+        $self['borderSize'] = $borderSize;
+
+        return $self;
+    }
+
+    /**
+     * A URL to link to when the image is clicked.
+     */
+    public function withHref(?string $href): self
+    {
+        $self = clone $this;
+        $self['href'] = $href;
+
+        return $self;
+    }
+
+    /**
+     * CSS padding applied around the image. For example, `10px`.
+     */
+    public function withPadding(?string $padding): self
+    {
+        $self = clone $this;
+        $self['padding'] = $padding;
+
+        return $self;
+    }
+
+    /**
+     * CSS width properties to apply to the image. For example, 50px.
+     */
+    public function withWidth(?string $width): self
+    {
+        $self = clone $this;
+        $self['width'] = $width;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember2/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember2/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember2;
+
+enum Type: string
+{
+    case IMAGE = 'image';
+}

--- a/src/ElementalNodeNonChannel/UnionMember3.php
+++ b/src/ElementalNodeNonChannel/UnionMember3.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Alignment;
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalActionNode\Style;
+use Courier\ElementalNodeNonChannel\UnionMember3\Type;
+use Courier\LocaleItem;
+
+/**
+ * Allows the user to execute an action. Can be a button or a link.
+ *
+ * @phpstan-import-type LocaleItemShape from \Courier\LocaleItem
+ *
+ * @phpstan-type UnionMember3Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   content: string,
+ *   href: string,
+ *   actionID?: string|null,
+ *   align?: null|Alignment|value-of<Alignment>,
+ *   backgroundColor?: string|null,
+ *   borderRadius?: string|null,
+ *   borderSize?: string|null,
+ *   disableTracking?: bool|null,
+ *   fontSize?: string|null,
+ *   locales?: array<string,LocaleItem|LocaleItemShape>|null,
+ *   padding?: string|null,
+ *   style?: null|Style|value-of<Style>,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember3 implements BaseModel
+{
+    /** @use SdkModel<UnionMember3Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * The text content of the action shown to the user.
+     */
+    #[Required]
+    public string $content;
+
+    /**
+     * The target URL of the action.
+     */
+    #[Required]
+    public string $href;
+
+    /**
+     * A unique id used to identify the action when it is executed.
+     */
+    #[Optional('action_id', nullable: true)]
+    public ?string $actionID;
+
+    /** @var value-of<Alignment>|null $align */
+    #[Optional(enum: Alignment::class)]
+    public ?string $align;
+
+    /**
+     * The background color of the action button.
+     */
+    #[Optional('background_color', nullable: true)]
+    public ?string $backgroundColor;
+
+    /**
+     * CSS border-radius applied to the action button. For example, `4px`.
+     */
+    #[Optional('border_radius', nullable: true)]
+    public ?string $borderRadius;
+
+    /**
+     * CSS border width applied to the action button. For example, `1px`.
+     */
+    #[Optional('border_size', nullable: true)]
+    public ?string $borderSize;
+
+    /**
+     * When true, the action's href is not rewritten for click-through tracking, even when click-through tracking is enabled for the workspace.
+     */
+    #[Optional('disable_tracking', nullable: true)]
+    public ?bool $disableTracking;
+
+    /**
+     * CSS font-size applied to the action button label. For example, `14px`.
+     */
+    #[Optional('font_size', nullable: true)]
+    public ?string $fontSize;
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @var array<string,LocaleItem>|null $locales
+     */
+    #[Optional(map: LocaleItem::class, nullable: true)]
+    public ?array $locales;
+
+    /**
+     * CSS padding applied to the action button. For example, `8px 16px`.
+     */
+    #[Optional(nullable: true)]
+    public ?string $padding;
+
+    /**
+     * Defaults to `button`.
+     *
+     * @var value-of<Style>|null $style
+     */
+    #[Optional(enum: Style::class, nullable: true)]
+    public ?string $style;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    /**
+     * `new UnionMember3()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * UnionMember3::with(content: ..., href: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new UnionMember3)->withContent(...)->withHref(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Alignment|value-of<Alignment>|null $align
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     * @param Style|value-of<Style>|null $style
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        string $content,
+        string $href,
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        ?string $actionID = null,
+        Alignment|string|null $align = null,
+        ?string $backgroundColor = null,
+        ?string $borderRadius = null,
+        ?string $borderSize = null,
+        ?bool $disableTracking = null,
+        ?string $fontSize = null,
+        ?array $locales = null,
+        ?string $padding = null,
+        Style|string|null $style = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        $self['content'] = $content;
+        $self['href'] = $href;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $actionID && $self['actionID'] = $actionID;
+        null !== $align && $self['align'] = $align;
+        null !== $backgroundColor && $self['backgroundColor'] = $backgroundColor;
+        null !== $borderRadius && $self['borderRadius'] = $borderRadius;
+        null !== $borderSize && $self['borderSize'] = $borderSize;
+        null !== $disableTracking && $self['disableTracking'] = $disableTracking;
+        null !== $fontSize && $self['fontSize'] = $fontSize;
+        null !== $locales && $self['locales'] = $locales;
+        null !== $padding && $self['padding'] = $padding;
+        null !== $style && $self['style'] = $style;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * The text content of the action shown to the user.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
+
+        return $self;
+    }
+
+    /**
+     * The target URL of the action.
+     */
+    public function withHref(string $href): self
+    {
+        $self = clone $this;
+        $self['href'] = $href;
+
+        return $self;
+    }
+
+    /**
+     * A unique id used to identify the action when it is executed.
+     */
+    public function withActionID(?string $actionID): self
+    {
+        $self = clone $this;
+        $self['actionID'] = $actionID;
+
+        return $self;
+    }
+
+    /**
+     * @param Alignment|value-of<Alignment> $align
+     */
+    public function withAlign(Alignment|string $align): self
+    {
+        $self = clone $this;
+        $self['align'] = $align;
+
+        return $self;
+    }
+
+    /**
+     * The background color of the action button.
+     */
+    public function withBackgroundColor(?string $backgroundColor): self
+    {
+        $self = clone $this;
+        $self['backgroundColor'] = $backgroundColor;
+
+        return $self;
+    }
+
+    /**
+     * CSS border-radius applied to the action button. For example, `4px`.
+     */
+    public function withBorderRadius(?string $borderRadius): self
+    {
+        $self = clone $this;
+        $self['borderRadius'] = $borderRadius;
+
+        return $self;
+    }
+
+    /**
+     * CSS border width applied to the action button. For example, `1px`.
+     */
+    public function withBorderSize(?string $borderSize): self
+    {
+        $self = clone $this;
+        $self['borderSize'] = $borderSize;
+
+        return $self;
+    }
+
+    /**
+     * When true, the action's href is not rewritten for click-through tracking, even when click-through tracking is enabled for the workspace.
+     */
+    public function withDisableTracking(?bool $disableTracking): self
+    {
+        $self = clone $this;
+        $self['disableTracking'] = $disableTracking;
+
+        return $self;
+    }
+
+    /**
+     * CSS font-size applied to the action button label. For example, `14px`.
+     */
+    public function withFontSize(?string $fontSize): self
+    {
+        $self = clone $this;
+        $self['fontSize'] = $fontSize;
+
+        return $self;
+    }
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     */
+    public function withLocales(?array $locales): self
+    {
+        $self = clone $this;
+        $self['locales'] = $locales;
+
+        return $self;
+    }
+
+    /**
+     * CSS padding applied to the action button. For example, `8px 16px`.
+     */
+    public function withPadding(?string $padding): self
+    {
+        $self = clone $this;
+        $self['padding'] = $padding;
+
+        return $self;
+    }
+
+    /**
+     * Defaults to `button`.
+     *
+     * @param Style|value-of<Style>|null $style
+     */
+    public function withStyle(Style|string|null $style): self
+    {
+        $self = clone $this;
+        $self['style'] = $style;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember3/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember3/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember3;
+
+enum Type: string
+{
+    case ACTION = 'action';
+}

--- a/src/ElementalNodeNonChannel/UnionMember4.php
+++ b/src/ElementalNodeNonChannel/UnionMember4.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember4\Type;
+
+/**
+ * Renders a dividing line between elements.
+ *
+ * @phpstan-type UnionMember4Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   color?: string|null,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember4 implements BaseModel
+{
+    /** @use SdkModel<UnionMember4Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * The CSS color to render the line with. For example, `#fff`.
+     */
+    #[Optional(nullable: true)]
+    public ?string $color;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        ?string $color = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $color && $self['color'] = $color;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * The CSS color to render the line with. For example, `#fff`.
+     */
+    public function withColor(?string $color): self
+    {
+        $self = clone $this;
+        $self['color'] = $color;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember4/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember4/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember4;
+
+enum Type: string
+{
+    case DIVIDER = 'divider';
+}

--- a/src/ElementalNodeNonChannel/UnionMember5.php
+++ b/src/ElementalNodeNonChannel/UnionMember5.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Alignment;
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember5\Type;
+use Courier\LocaleItem;
+use Courier\TextStyle;
+
+/**
+ * Renders a quote block.
+ *
+ * @phpstan-import-type LocaleItemShape from \Courier\LocaleItem
+ *
+ * @phpstan-type UnionMember5Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   content: string,
+ *   align?: null|Alignment|value-of<Alignment>,
+ *   borderColor?: string|null,
+ *   fontSize?: string|null,
+ *   lineHeight?: string|null,
+ *   locales?: array<string,LocaleItem|LocaleItemShape>|null,
+ *   textStyle?: null|TextStyle|value-of<TextStyle>,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember5 implements BaseModel
+{
+    /** @use SdkModel<UnionMember5Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * The text value of the quote.
+     */
+    #[Required]
+    public string $content;
+
+    /** @var value-of<Alignment>|null $align */
+    #[Optional(enum: Alignment::class)]
+    public ?string $align;
+
+    /**
+     * CSS border color property. For example, `#fff`.
+     */
+    #[Optional('border_color', nullable: true)]
+    public ?string $borderColor;
+
+    /**
+     * CSS px font size for this quote block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
+     */
+    #[Optional('font_size', nullable: true)]
+    public ?string $fontSize;
+
+    /**
+     * CSS line height for this quote block, as a px value or a unitless multiplier, e.g. `24px` or `1.5`. Email only.
+     */
+    #[Optional('line_height', nullable: true)]
+    public ?string $lineHeight;
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @var array<string,LocaleItem>|null $locales
+     */
+    #[Optional(map: LocaleItem::class, nullable: true)]
+    public ?array $locales;
+
+    /** @var value-of<TextStyle>|null $textStyle */
+    #[Optional('text_style', enum: TextStyle::class)]
+    public ?string $textStyle;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    /**
+     * `new UnionMember5()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * UnionMember5::with(content: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new UnionMember5)->withContent(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param Alignment|value-of<Alignment>|null $align
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     * @param TextStyle|value-of<TextStyle>|null $textStyle
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        string $content,
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        Alignment|string|null $align = null,
+        ?string $borderColor = null,
+        ?string $fontSize = null,
+        ?string $lineHeight = null,
+        ?array $locales = null,
+        TextStyle|string|null $textStyle = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        $self['content'] = $content;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $align && $self['align'] = $align;
+        null !== $borderColor && $self['borderColor'] = $borderColor;
+        null !== $fontSize && $self['fontSize'] = $fontSize;
+        null !== $lineHeight && $self['lineHeight'] = $lineHeight;
+        null !== $locales && $self['locales'] = $locales;
+        null !== $textStyle && $self['textStyle'] = $textStyle;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * The text value of the quote.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
+
+        return $self;
+    }
+
+    /**
+     * @param Alignment|value-of<Alignment> $align
+     */
+    public function withAlign(Alignment|string $align): self
+    {
+        $self = clone $this;
+        $self['align'] = $align;
+
+        return $self;
+    }
+
+    /**
+     * CSS border color property. For example, `#fff`.
+     */
+    public function withBorderColor(?string $borderColor): self
+    {
+        $self = clone $this;
+        $self['borderColor'] = $borderColor;
+
+        return $self;
+    }
+
+    /**
+     * CSS px font size for this quote block, e.g. `16px`. Overrides the size of the `text_style` preset. Email only.
+     */
+    public function withFontSize(?string $fontSize): self
+    {
+        $self = clone $this;
+        $self['fontSize'] = $fontSize;
+
+        return $self;
+    }
+
+    /**
+     * CSS line height for this quote block, as a px value or a unitless multiplier, e.g. `24px` or `1.5`. Email only.
+     */
+    public function withLineHeight(?string $lineHeight): self
+    {
+        $self = clone $this;
+        $self['lineHeight'] = $lineHeight;
+
+        return $self;
+    }
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     */
+    public function withLocales(?array $locales): self
+    {
+        $self = clone $this;
+        $self['locales'] = $locales;
+
+        return $self;
+    }
+
+    /**
+     * @param TextStyle|value-of<TextStyle> $textStyle
+     */
+    public function withTextStyle(TextStyle|string $textStyle): self
+    {
+        $self = clone $this;
+        $self['textStyle'] = $textStyle;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember5/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember5/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember5;
+
+enum Type: string
+{
+    case QUOTE = 'quote';
+}

--- a/src/ElementalNodeNonChannel/UnionMember6.php
+++ b/src/ElementalNodeNonChannel/UnionMember6.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel;
+
+use Courier\Core\Attributes\Optional;
+use Courier\Core\Attributes\Required;
+use Courier\Core\Concerns\SdkModel;
+use Courier\Core\Contracts\BaseModel;
+use Courier\ElementalNodeNonChannel\UnionMember6\Type;
+use Courier\LocaleItem;
+
+/**
+ * Raw HTML string inside an Elemental document. When rendering a message, this node is turned into output only for the email channel; for other channels it produces no blocks.
+ *
+ * @phpstan-import-type LocaleItemShape from \Courier\LocaleItem
+ *
+ * @phpstan-type UnionMember6Shape = array{
+ *   channels?: list<string>|null,
+ *   if?: string|null,
+ *   loop?: string|null,
+ *   ref?: string|null,
+ *   content: string,
+ *   locales?: array<string,LocaleItem|LocaleItemShape>|null,
+ *   type?: null|Type|value-of<Type>,
+ * }
+ */
+final class UnionMember6 implements BaseModel
+{
+    /** @use SdkModel<UnionMember6Shape> */
+    use SdkModel;
+
+    /** @var list<string>|null $channels */
+    #[Optional(list: 'string', nullable: true)]
+    public ?array $channels;
+
+    #[Optional(nullable: true)]
+    public ?string $if;
+
+    #[Optional(nullable: true)]
+    public ?string $loop;
+
+    #[Optional(nullable: true)]
+    public ?string $ref;
+
+    /**
+     * Raw HTML string to render inside the notification.
+     */
+    #[Required]
+    public string $content;
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @var array<string,LocaleItem>|null $locales
+     */
+    #[Optional(map: LocaleItem::class, nullable: true)]
+    public ?array $locales;
+
+    /** @var value-of<Type>|null $type */
+    #[Optional(enum: Type::class)]
+    public ?string $type;
+
+    /**
+     * `new UnionMember6()` is missing required properties by the API.
+     *
+     * To enforce required parameters use
+     * ```
+     * UnionMember6::with(content: ...)
+     * ```
+     *
+     * Otherwise ensure the following setters are called
+     *
+     * ```
+     * (new UnionMember6)->withContent(...)
+     * ```
+     */
+    public function __construct()
+    {
+        $this->initialize();
+    }
+
+    /**
+     * Construct an instance from the required parameters.
+     *
+     * You must use named parameters to construct any parameters with a default value.
+     *
+     * @param list<string>|null $channels
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     * @param Type|value-of<Type>|null $type
+     */
+    public static function with(
+        string $content,
+        ?array $channels = null,
+        ?string $if = null,
+        ?string $loop = null,
+        ?string $ref = null,
+        ?array $locales = null,
+        Type|string|null $type = null,
+    ): self {
+        $self = new self;
+
+        $self['content'] = $content;
+
+        null !== $channels && $self['channels'] = $channels;
+        null !== $if && $self['if'] = $if;
+        null !== $loop && $self['loop'] = $loop;
+        null !== $ref && $self['ref'] = $ref;
+        null !== $locales && $self['locales'] = $locales;
+        null !== $type && $self['type'] = $type;
+
+        return $self;
+    }
+
+    /**
+     * @param list<string>|null $channels
+     */
+    public function withChannels(?array $channels): self
+    {
+        $self = clone $this;
+        $self['channels'] = $channels;
+
+        return $self;
+    }
+
+    public function withIf(?string $if): self
+    {
+        $self = clone $this;
+        $self['if'] = $if;
+
+        return $self;
+    }
+
+    public function withLoop(?string $loop): self
+    {
+        $self = clone $this;
+        $self['loop'] = $loop;
+
+        return $self;
+    }
+
+    public function withRef(?string $ref): self
+    {
+        $self = clone $this;
+        $self['ref'] = $ref;
+
+        return $self;
+    }
+
+    /**
+     * Raw HTML string to render inside the notification.
+     */
+    public function withContent(string $content): self
+    {
+        $self = clone $this;
+        $self['content'] = $content;
+
+        return $self;
+    }
+
+    /**
+     * Region specific content. See [locales docs](https://www.courier.com/docs/platform/content/elemental/locales/) for more details.
+     *
+     * @param array<string,LocaleItem|LocaleItemShape>|null $locales
+     */
+    public function withLocales(?array $locales): self
+    {
+        $self = clone $this;
+        $self['locales'] = $locales;
+
+        return $self;
+    }
+
+    /**
+     * @param Type|value-of<Type> $type
+     */
+    public function withType(Type|string $type): self
+    {
+        $self = clone $this;
+        $self['type'] = $type;
+
+        return $self;
+    }
+}

--- a/src/ElementalNodeNonChannel/UnionMember6/Type.php
+++ b/src/ElementalNodeNonChannel/UnionMember6/Type.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Courier\ElementalNodeNonChannel\UnionMember6;
+
+enum Type: string
+{
+    case HTML = 'html';
+}

--- a/src/Journeys/Templates/TemplateCreateParams.php
+++ b/src/Journeys/Templates/TemplateCreateParams.php
@@ -14,6 +14,8 @@ use Courier\Journeys\Templates\TemplateCreateParams\Notification;
 /**
  * Create a notification template scoped to this journey. Defaults to `DRAFT` state; pass `state: "PUBLISHED"` to publish on create.
  *
+ * The content tree must contain exactly one channel block whose `channel` matches the `channel` on the request — a journey-scoped template carries a single channel. Top-level elements, or a block for a different channel, return `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted.
+ *
  * @see Courier\Services\Journeys\TemplatesService::create()
  *
  * @phpstan-import-type NotificationShape from \Courier\Journeys\Templates\TemplateCreateParams\Notification

--- a/src/Notifications/NotificationCreateParams.php
+++ b/src/Notifications/NotificationCreateParams.php
@@ -14,6 +14,8 @@ use Courier\Notifications\NotificationCreateParams\State;
 /**
  * Create a notification template. Requires all fields in the notification object. Templates are created in draft state by default.
  *
+ * Content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, and the requirement applies to creation only: `PUT /notifications/{id}` still accepts unwrapped content. Note this endpoint takes versioned content only — the `{ title, body }` shorthand accepted by `/send` is rejected here with an `invalid_request_error` on `notification.content.version`.
+ *
  * @see Courier\Services\NotificationsService::create()
  *
  * @phpstan-import-type NotificationTemplateWritePayloadShape from \Courier\Notifications\NotificationTemplateWritePayload

--- a/src/Notifications/NotificationTemplateUpdateRequest.php
+++ b/src/Notifications/NotificationTemplateUpdateRequest.php
@@ -11,7 +11,7 @@ use Courier\Core\Contracts\BaseModel;
 use Courier\Notifications\NotificationTemplateUpdateRequest\State;
 
 /**
- * Request body for replacing a notification template. Same shape as create. All fields required (PUT = full replacement), except `alias`, whose omission means "leave the existing aliases alone".
+ * Request body for replacing a notification template. All fields are required, since `PUT` is a full replacement, except `alias`, whose omission leaves the existing aliases in place. Unlike `NotificationTemplateCreateRequest`, `notification.content` is not required to place its elements inside a channel block: the requirement applies to creation only, so templates already stored without one stay editable.
  *
  * @phpstan-import-type NotificationTemplateWritePayloadShape from \Courier\Notifications\NotificationTemplateWritePayload
  *

--- a/src/Services/Journeys/TemplatesRawService.php
+++ b/src/Services/Journeys/TemplatesRawService.php
@@ -52,6 +52,8 @@ final class TemplatesRawService implements TemplatesRawContract
      *
      * Create a notification template scoped to this journey. Defaults to `DRAFT` state; pass `state: "PUBLISHED"` to publish on create.
      *
+     * The content tree must contain exactly one channel block whose `channel` matches the `channel` on the request — a journey-scoped template carries a single channel. Top-level elements, or a block for a different channel, return `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted.
+     *
      * @param string $templateID Path param: Journey id
      * @param array{
      *   channel: string,

--- a/src/Services/Journeys/TemplatesService.php
+++ b/src/Services/Journeys/TemplatesService.php
@@ -48,6 +48,8 @@ final class TemplatesService implements TemplatesContract
      *
      * Create a notification template scoped to this journey. Defaults to `DRAFT` state; pass `state: "PUBLISHED"` to publish on create.
      *
+     * The content tree must contain exactly one channel block whose `channel` matches the `channel` on the request — a journey-scoped template carries a single channel. Top-level elements, or a block for a different channel, return `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted.
+     *
      * @param string $templateID Path param: Journey id
      * @param string $channel Body param
      * @param Notification|NotificationShape $notification Body param

--- a/src/Services/NotificationsRawService.php
+++ b/src/Services/NotificationsRawService.php
@@ -57,6 +57,8 @@ final class NotificationsRawService implements NotificationsRawContract
      *
      * Create a notification template. Requires all fields in the notification object. Templates are created in draft state by default.
      *
+     * Content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, and the requirement applies to creation only: `PUT /notifications/{id}` still accepts unwrapped content. Note this endpoint takes versioned content only — the `{ title, body }` shorthand accepted by `/send` is rejected here with an `invalid_request_error` on `notification.content.version`.
+     *
      * @param array{
      *   notification: NotificationTemplateWritePayload|NotificationTemplateWritePayloadShape,
      *   state?: State|value-of<State>,

--- a/src/Services/NotificationsService.php
+++ b/src/Services/NotificationsService.php
@@ -58,6 +58,8 @@ final class NotificationsService implements NotificationsContract
      *
      * Create a notification template. Requires all fields in the notification object. Templates are created in draft state by default.
      *
+     * Content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, and the requirement applies to creation only: `PUT /notifications/{id}` still accepts unwrapped content. Note this endpoint takes versioned content only — the `{ title, body }` shorthand accepted by `/send` is rejected here with an `invalid_request_error` on `notification.content.version`.
+     *
      * @param NotificationTemplateWritePayload|NotificationTemplateWritePayloadShape $notification body param: Template fields accepted in POST and PUT request bodies, nested under a `notification` key
      * @param State|value-of<State> $state Body param: Template state after creation. Case-insensitive input, normalized to uppercase in the response. Defaults to "DRAFT".
      * @param string $idempotencyKey Header param: A unique key that makes this request idempotent. If Courier receives another request with the same `Idempotency-Key`, it returns the stored response from the first request without performing the operation again (including the original status code and any error). Use it to safely retry `POST` requests after network failures without risking duplicate sends. The key is scoped to this endpoint.

--- a/src/Services/Tenants/TemplatesRawService.php
+++ b/src/Services/Tenants/TemplatesRawService.php
@@ -175,6 +175,8 @@ final class TemplatesRawService implements TemplatesRawContract
      *
      * Creates or updates a notification template scoped to one tenant, letting a tenant override the content the workspace template would send.
      *
+     * This is an upsert: it creates when the tenant has no template under `template_id`, and updates when it does. On the create half, content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, as is the `{ title, body }` shorthand, which has no elements to wrap. Updates are not checked, so tenant templates already stored without a wrapper stay editable.
+     *
      * @param string $templateID path param: Id of the template to be created or updated
      * @param array{
      *   tenantID: string,

--- a/src/Services/Tenants/TemplatesService.php
+++ b/src/Services/Tenants/TemplatesService.php
@@ -150,6 +150,8 @@ final class TemplatesService implements TemplatesContract
      *
      * Creates or updates a notification template scoped to one tenant, letting a tenant override the content the workspace template would send.
      *
+     * This is an upsert: it creates when the tenant has no template under `template_id`, and updates when it does. On the create half, content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, as is the `{ title, body }` shorthand, which has no elements to wrap. Updates are not checked, so tenant templates already stored without a wrapper stay editable.
+     *
      * @param string $templateID path param: Id of the template to be created or updated
      * @param string $tenantID path param: Id of the tenant for which to create or update the template
      * @param TenantTemplateInput|TenantTemplateInputShape $template Body param: Template configuration for creating or updating a tenant notification template

--- a/src/Tenants/Templates/TemplateReplaceParams.php
+++ b/src/Tenants/Templates/TemplateReplaceParams.php
@@ -14,6 +14,8 @@ use Courier\Tenants\TenantTemplateInput;
 /**
  * Creates or updates a notification template scoped to one tenant, letting a tenant override the content the workspace template would send.
  *
+ * This is an upsert: it creates when the tenant has no template under `template_id`, and updates when it does. On the create half, content must place its elements inside a channel block — `{ "type": "channel", "channel": "email", "elements": [...] }` — or the request returns `400`. The template designer renders only the channel block matching the tab it draws, so content stored without one cannot be opened. An empty `elements` array is accepted, as is the `{ title, body }` shorthand, which has no elements to wrap. Updates are not checked, so tenant templates already stored without a wrapper stay editable.
+ *
  * @see Courier\Services\Tenants\TemplatesService::replace()
  *
  * @phpstan-import-type TenantTemplateInputShape from \Courier\Tenants\TenantTemplateInput

--- a/tests/Services/Journeys/TemplatesTest.php
+++ b/tests/Services/Journeys/TemplatesTest.php
@@ -69,7 +69,7 @@ final class TemplatesTest extends TestCase
             notification: [
                 'brand' => ['id' => 'id'],
                 'content' => [
-                    'elements' => [['type' => 'text']],
+                    'elements' => [['type' => 'channel']],
                     'version' => '2022-01-01',
                     'scope' => 'default',
                 ],

--- a/tests/Services/Tenants/TemplatesTest.php
+++ b/tests/Services/Tenants/TemplatesTest.php
@@ -170,7 +170,7 @@ final class TemplatesTest extends TestCase
             tenantID: 'tenant_id',
             template: [
                 'content' => [
-                    'elements' => [['type' => 'text']], 'version' => '2022-01-01',
+                    'elements' => [['type' => 'channel']], 'version' => '2022-01-01',
                 ],
                 'channels' => [
                     'foo' => [


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

30 files changed, 2024 insertions(+), 4 deletions(-)

<details><summary>Files</summary>

```
 src/Client.php                                          |   2 +-
 src/ElementalChannelNode.php                            |  32 +++
 src/ElementalChannelNodeWithType.php                    |  32 +++
 src/ElementalNodeNonChannel.php                         |  51 +++++
 src/ElementalNodeNonChannel/UnionMember0.php            | 377 ++++++++++++++++++++++++++++++++++
 src/ElementalNodeNonChannel/UnionMember0/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember1.php            | 141 +++++++++++++
 src/ElementalNodeNonChannel/UnionMember1/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember2.php            | 297 +++++++++++++++++++++++++++
 src/ElementalNodeNonChannel/UnionMember2/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember3.php            | 391 ++++++++++++++++++++++++++++++++++++
 src/ElementalNodeNonChannel/UnionMember3/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember4.php            | 141 +++++++++++++
 src/ElementalNodeNonChannel/UnionMember4/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember5.php            | 285 ++++++++++++++++++++++++++
 src/ElementalNodeNonChannel/UnionMember5/Type.php       |  10 +
 src/ElementalNodeNonChannel/UnionMember6.php            | 185 +++++++++++++++++
 src/ElementalNodeNonChannel/UnionMember6/Type.php       |  10 +
 src/Journeys/Templates/TemplateCreateParams.php         |   2 +
 src/Notifications/NotificationCreateParams.php          |   2 +
 src/Notifications/NotificationTemplateUpdateRequest.php |   2 +-
 src/Services/Journeys/TemplatesRawService.php           |   2 +
 src/Services/Journeys/TemplatesService.php              |   2 +
 src/Services/NotificationsRawService.php                |   2 +
 src/Services/NotificationsService.php                   |   2 +
 src/Services/Tenants/TemplatesRawService.php            |   2 +
 src/Services/Tenants/TemplatesService.php               |   2 +
 src/Tenants/Templates/TemplateReplaceParams.php         |   2 +
 tests/Services/Journeys/TemplatesTest.php               |   2 +-
 tests/Services/Tenants/TemplatesTest.php                |   2 +-
 30 files changed, 2024 insertions(+), 4 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
